### PR TITLE
Add `set -eu` to tests/start_services.sh

### DIFF
--- a/tests/start_services.sh
+++ b/tests/start_services.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eu
 
 COMPOSE="docker-compose -f tests/docker-compose.yml"
 TEST_DIR="./tests/tmp"


### PR DESCRIPTION
This will fix RGB-Tools/rgb-lib#2 .

<details>
<summary>$ sudo apt remove docker-compose && cargo test -- --test-threads=1</summary>
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  python3-attr python3-cached-property python3-certifi python3-chardet python3-docker python3-dockerpty python3-docopt python3-idna python3-importlib-metadata python3-jsonschema python3-more-itertools
  python3-pyrsistent python3-requests python3-six python3-texttable python3-urllib3 python3-websocket python3-zipp
Use 'sudo apt autoremove' to remove them.
The following packages will be REMOVED:
  docker-compose
0 upgraded, 0 newly installed, 1 to remove and 0 not upgraded.
After this operation, 692 kB disk space will be freed.
Do you want to continue? [Y/n]
(Reading database ... 139530 files and directories currently installed.)
Removing docker-compose (1.25.0-1) ...
Processing triggers for man-db (2.9.4-2) ...
    Finished test [unoptimized + debuginfo] target(s) in 0.31s
     Running unittests src/lib.rs (target/debug/deps/rgb_lib-33b59c365985afd6)

running 37 tests
test wallet::test::blind::expire ... FAILED
test wallet::test::blind::fail ... FAILED
test wallet::test::blind::pending_transfer_skip ... FAILED
test wallet::test::blind::success ... FAILED
test wallet::test::create_utxos::fail ... FAILED
test wallet::test::create_utxos::success ... FAILED
test wallet::test::delete_transfers::fail ... FAILED
test wallet::test::delete_transfers::success ... FAILED
test wallet::test::drain_to::fail ... FAILED
test wallet::test::drain_to::success ... FAILED
test wallet::test::fail_transfers::fail ... FAILED
test wallet::test::fail_transfers::success ... FAILED
test wallet::test::get_address::success ... ok
test wallet::test::get_asset_balance::success ... FAILED
test wallet::test::get_asset_balance::transfer_balances ... FAILED
test wallet::test::go_online::consistency_check_fail_asset_ids ... FAILED
test wallet::test::go_online::consistency_check_fail_utxos ... FAILED
test wallet::test::go_online::fail ... ok
test wallet::test::go_online::success ... ok
test wallet::test::issue_asset::fail ... FAILED
test wallet::test::issue_asset::success ... FAILED
test wallet::test::issue_asset::zero_amount_fail ... ignored, currently succeeds
test wallet::test::list_assets::success ... FAILED
test wallet::test::list_transfers::fail ... FAILED
test wallet::test::list_transfers::success ... FAILED
test wallet::test::list_unspents::success ... FAILED
test wallet::test::new::fail ... ok
test wallet::test::new::success ... ok
test wallet::test::send::fail ... FAILED
test wallet::test::send::multiple_assets_success ... ignored, requires MAX_ALLOCATIONS_PER_UTXO > 1
test wallet::test::send::pending_incoming_transfer_fail ... ignored, requires MAX_ALLOCATIONS_PER_UTXO > 1
test wallet::test::send::pending_outgoing_transfer_fail ... FAILED
test wallet::test::send::pending_transfer_input_fail ... ignored, requires MAX_ALLOCATIONS_PER_UTXO > 1
test wallet::test::send::send_begin_success ... FAILED
test wallet::test::send::send_received_success ... ignored
test wallet::test::send::send_twice_success ... FAILED
test wallet::test::send::success ... FAILED

failures:

---- wallet::test::blind::expire stdout ----
starting test services...
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- wallet::test::blind::fail stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::blind::pending_transfer_skip stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::blind::success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::create_utxos::fail stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::create_utxos::success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::delete_transfers::fail stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::delete_transfers::success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::drain_to::fail stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::drain_to::success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::fail_transfers::fail stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::fail_transfers::success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::get_asset_balance::success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::get_asset_balance::transfer_balances stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::go_online::consistency_check_fail_asset_ids stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::go_online::consistency_check_fail_utxos stdout ----
wallet directory: "/home/monaka/git/rgb-lib/tests/tmp/7c923e1d"
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::issue_asset::fail stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::issue_asset::success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::list_assets::success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::list_transfers::fail stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::list_transfers::success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::list_unspents::success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::send::fail stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::send::pending_outgoing_transfer_fail stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::send::send_begin_success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::send::send_twice_success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10

---- wallet::test::send::success stdout ----
thread 'main' panicked at 'failed to fund wallet: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/wallet/test/mod.rs:43:10


failures:
    wallet::test::blind::expire
    wallet::test::blind::fail
    wallet::test::blind::pending_transfer_skip
    wallet::test::blind::success
    wallet::test::create_utxos::fail
    wallet::test::create_utxos::success
    wallet::test::delete_transfers::fail
    wallet::test::delete_transfers::success
    wallet::test::drain_to::fail
    wallet::test::drain_to::success
    wallet::test::fail_transfers::fail
    wallet::test::fail_transfers::success
    wallet::test::get_asset_balance::success
    wallet::test::get_asset_balance::transfer_balances
    wallet::test::go_online::consistency_check_fail_asset_ids
    wallet::test::go_online::consistency_check_fail_utxos
    wallet::test::issue_asset::fail
    wallet::test::issue_asset::success
    wallet::test::list_assets::success
    wallet::test::list_transfers::fail
    wallet::test::list_transfers::success
    wallet::test::list_unspents::success
    wallet::test::send::fail
    wallet::test::send::pending_outgoing_transfer_fail
    wallet::test::send::send_begin_success
    wallet::test::send::send_twice_success
    wallet::test::send::success

test result: FAILED. 5 passed; 27 failed; 5 ignored; 0 measured; 0 filtered out; finished in 26.95s

error: test failed, to rerun pass '--lib'
</details>
