### PR TITLE
Add `-T` options to `docker-compose exec` in tests/start_services.sh.

### DIFF
--- a/tests/start_services.sh
+++ b/tests/start_services.sh
@@ -14,7 +14,7 @@ until $COMPOSE logs bitcoind |grep 'Bound to'; do
 done
 
 # prepare bitcoin funds
-BCLI="$COMPOSE exec -u blits bitcoind bitcoin-cli -regtest"
+BCLI="$COMPOSE exec -T -u blits bitcoind bitcoin-cli -regtest"
 $BCLI createwallet miner
 $BCLI -rpcwallet=miner -generate 103
 


### PR DESCRIPTION
This enables to run in GitHub Actions.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>