### PR TITLE
Add a new API `Wallet::new_with_online()`.

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -671,6 +671,11 @@ pub struct Wallet {
 impl Wallet {
     /// Create a new RGB wallet based on the provided [`WalletData`]
     pub fn new(wallet_data: WalletData) -> Result<Self, Error> {
+        Self::new_with_online(wallet_data, None)
+    }
+
+    /// Create a new RGB wallet based on the provided [`WalletData`] and [`Option<Online>`]
+    pub fn new_with_online(wallet_data: WalletData, online: Option<Online>) -> Result<Self, Error> {
         let wdata = wallet_data.clone();
 
         // wallet directory and file logging setup
@@ -768,7 +773,7 @@ impl Wallet {
             wallet_dir,
             bdk_wallet,
             rest_client,
-            online: None,
+            online,
             bdk_blockchain: None,
             electrum_client: None,
             rgb_client: None,

--- a/src/wallet/test/new.rs
+++ b/src/wallet/test/new.rs
@@ -75,6 +75,34 @@ fn mainnet_success() {
 }
 
 #[test]
+fn mainnet_with_online_success() {
+    fs::create_dir_all(TEST_DATA_DIR).unwrap();
+
+    let bitcoin_network = BitcoinNetwork::Mainnet;
+    let keys = generate_keys(bitcoin_network);
+    let wallet = Wallet::new_with_online(
+        WalletData {
+            data_dir: TEST_DATA_DIR.to_string(),
+            bitcoin_network,
+            database_type: DatabaseType::Sqlite,
+            pubkey: keys.xpub.clone(),
+            mnemonic: Some(keys.mnemonic.clone()),
+        },
+        Some(Online {
+            id: 1,
+            electrum_url: "".to_string(),
+            proxy_url: "".to_string(),
+        }),
+    )
+    .unwrap();
+    check_wallet(&wallet, DescriptorType::Wpkh, bitcoin_network);
+    assert!(!wallet.watch_only);
+    assert_eq!(wallet.wallet_data.pubkey, keys.xpub);
+    assert_eq!(wallet.wallet_data.mnemonic, Some(keys.mnemonic));
+    assert!(wallet.online.is_some());
+}
+
+#[test]
 fn fail() {
     initialize();
 


### PR DESCRIPTION
I'm developing RESTful http interface for RGB-Lib.
This PR is for my app.

As you might know, web frameworks tends to be stateless.
So I want to keep my Wallet instance over sessions.
But as far as I trided, the instance of Wallet structure couldn't store in reference count traits like `Rc<>` or `Arc<>`. 

I also tried instancing `Wallet` per session.
Results were "panicked" because of thread generation in `_go_online()`.

This PR enables to inject `Online` object when a Wallet instance is created.
This approach is kept a backward compatibility. All tests are passed.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
