### PR TITLE
Use the path `/tmp/tests/tmp` on Docs.rs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT"
 description = "RGB wallet library"
 exclude = ["migration"]
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]
+
 [workspace]
 members = [".", "migration"]
 

--- a/src/wallet/test/mod.rs
+++ b/src/wallet/test/mod.rs
@@ -10,7 +10,13 @@ use super::*;
 
 const PROXY_URL: &str = "http://proxy.rgbtools.org";
 const ELECTRUM_URL: &str = "127.0.0.1:50001";
+
+#[cfg(not(docsrs))]
 const TEST_DATA_DIR: &str = "./tests/tmp";
+
+#[cfg(docsrs)]
+const TEST_DATA_DIR: &str = "/tmp/tests/tmp";
+
 const TICKER: &str = "TICKER";
 const NAME: &str = "name";
 const DESCRIPTION: &str = "DESCRIPTION";

--- a/tests/start_services.sh
+++ b/tests/start_services.sh
@@ -10,7 +10,11 @@ else
     exit 1
 fi
 COMPOSE="$COMPOSE_CMD -f tests/docker-compose.yml"
-TEST_DIR="./tests/tmp"
+if [[ -n "$DOCS_RS" ]]; then
+    TEST_DIR="/tmp/tests/tmp"
+else
+    TEST_DIR="./tests/tmp"
+fi
 
 $COMPOSE down -v
 rm -rf $TEST_DIR


### PR DESCRIPTION
See also: https://docs.rs/about/builds#detecting-docsrs
          https://docs.rs/about/builds#cross-compiling

This will fix #19.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
