### PR TITLE
Add cli crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -268,7 +268,7 @@ dependencies = [
  "futures-lite",
  "libc",
  "signal-hook",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -845,8 +845,8 @@ checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
  "strsim",
@@ -855,12 +855,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+dependencies = [
+ "bitflags",
+ "clap_derive 4.1.0",
+ "clap_lex 0.3.2",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
 name = "clap_complete"
 version = "3.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
 dependencies = [
- "clap",
+ "clap 3.2.23",
 ]
 
 [[package]]
@@ -877,10 +892,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "clap_lex"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1505,6 +1542,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +1932,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,10 +2181,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "itertools"
@@ -2302,6 +2388,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lnp-core"
@@ -2617,7 +2709,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3046,7 +3138,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3452,7 +3544,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_scripts",
  "bp-core",
- "clap",
+ "clap 3.2.23",
  "commit_verify",
  "descriptor-wallet",
  "electrum-client",
@@ -3511,7 +3603,7 @@ dependencies = [
  "amplify",
  "bitcoin",
  "bp-core",
- "clap",
+ "clap 3.2.23",
  "clap_complete",
  "colored",
  "commit_verify",
@@ -3558,6 +3650,17 @@ dependencies = [
  "serde_yaml 0.9.17",
  "storm-core",
  "strict_encoding",
+]
+
+[[package]]
+name = "rgblib-tool"
+version = "0.1.0"
+dependencies = [
+ "amplify",
+ "clap 4.1.6",
+ "rgb-lib",
+ "serde 1.0.152",
+ "serde_json",
 ]
 
 [[package]]
@@ -3685,6 +3788,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3723,7 +3840,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -3783,7 +3900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ebe1f820fe8949cf6a57272ba9ebd0be766e47c9b85c04b3cabea40ab9459b3"
 dependencies = [
  "chrono",
- "clap",
+ "clap 3.2.23",
  "dotenvy",
  "regex",
  "sea-schema",
@@ -3812,7 +3929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ed3cdfa669e4c385922f902b9a58e0c2128782a4d0fe79c6c34f3b927565e5b"
 dependencies = [
  "async-trait",
- "clap",
+ "clap 3.2.23",
  "dotenvy",
  "sea-orm",
  "sea-orm-cli",
@@ -4483,7 +4600,7 @@ dependencies = [
  "amplify",
  "bitcoin_hashes 0.11.0",
  "chrono",
- "clap",
+ "clap 3.2.23",
  "clap_complete",
  "colored",
  "commit_verify",
@@ -4806,7 +4923,7 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -5299,6 +5416,30 @@ name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "rgb-lib"
 version = "0.1.7"
-authors = ["Zoe Faltibà <zoefaltiba@gmail.com>", "Nicola Busanello <nicola.busanello@gmail.com>"]
+authors = [
+    "Zoe Faltibà <zoefaltiba@gmail.com>",
+    "Nicola Busanello <nicola.busanello@gmail.com>",
+]
 edition = "2021"
 rust-version = "1.59.0"
 repository = "https://github.com/RGB-Tools/rgb-lib"
@@ -11,18 +14,33 @@ description = "RGB wallet library"
 exclude = ["migration"]
 
 [workspace]
-members = [".", "migration"]
+members = [".", "migration", "cli"]
 
 [dependencies]
 base64 = "0.13.0"
-bdk = { version = "0.25", features = ["electrum", "keys-bip39", "sqlite-bundled"] }
+bdk = { version = "0.25", features = [
+    "electrum",
+    "keys-bip39",
+    "sqlite-bundled",
+] }
 bitcoin = "0.29.2"
 chrono = "0.4.23"
 electrum-client = "0.12.0"
 futures = "0.3"
 rgb-lib-migration = { path = "migration", version = "0.1.7" }
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "multipart", "native-tls"] }
-sea-orm = { version = "^0.10.6", features = ["sqlx-mysql", "sqlx-postgres", "sqlx-sqlite", "runtime-async-std-native-tls", "macros"] }
+reqwest = { version = "0.11", default-features = false, features = [
+    "blocking",
+    "json",
+    "multipart",
+    "native-tls",
+] }
+sea-orm = { version = "^0.10.6", features = [
+    "sqlx-mysql",
+    "sqlx-postgres",
+    "sqlx-sqlite",
+    "runtime-async-std-native-tls",
+    "macros",
+] }
 sea-query = "=0.28.0"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "rgblib-tool"
+version = "0.1.0"
+edition = "2021"
+authors = [
+    "Zoe Faltibà <zoefaltiba@gmail.com>",
+    "Nicola Busanello <nicola.busanello@gmail.com>",
+    "Joe Miyamoto <joemphilips@gmail.com>",
+]
+license = "MIT"
+description = "tool to use rgb-lib functionality from cli"
+
+[[bin]]
+name = "rgblib-tool"
+path = "src/main.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+amplify = "^3.13.0"
+clap = { version = "4.1.6", features = ["derive", "env"] }
+rgb-lib = { version = "0.1.7", path = ".." }
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = { version = "^1.0" }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,188 @@
+mod opts;
+
+mod wallet_helpers;
+
+use std::error::Error;
+
+use amplify::map;
+use clap::Parser;
+use opts::{AssetCommand, Command, IssueCommand, NativeWalletCommand, TransferCommand};
+use rgb_lib::{
+    wallet::{Online, Recipient, WalletData},
+    Wallet,
+};
+
+use crate::{opts::Opts, wallet_helpers::assure_utxos_synced};
+
+fn handle_transfer_command(
+    mut wallet: Wallet,
+    opts: Opts,
+    cmd: TransferCommand,
+) -> Result<(), Box<dyn Error + 'static>> {
+    match cmd {
+        TransferCommand::List { asset_id } => {
+            let t = wallet.list_transfers(asset_id)?;
+            println!("{}", serde_json::to_string(&t)?);
+        }
+        TransferCommand::Send {
+            amount,
+            asset_id,
+            blinded_utxo,
+            consignment_endpoints,
+            donation,
+            fee_rate,
+        } => {
+            let online =
+                wallet.go_online(false, opts.electrum_url.expect("needs electrum_url option"))?;
+
+            let recipient_map =
+                map! { asset_id => vec![Recipient{ blinded_utxo, amount, consignment_endpoints }] };
+
+            let fee_rate: f32 = (fee_rate * 1000) as f32;
+            let r = wallet.send(online, recipient_map, donation, fee_rate)?;
+            println!("{}", r);
+        }
+        TransferCommand::Fail {
+            blinded_utxo,
+            txid,
+            no_asset_only,
+        } => {
+            let online =
+                wallet.go_online(false, opts.electrum_url.expect("needs electrum_url option"))?;
+            let i = wallet.fail_transfers(online, blinded_utxo, txid, no_asset_only)?;
+            println!("{}", i);
+        }
+        TransferCommand::Delete {
+            blinded_utxo,
+            txid,
+            no_asset_only,
+        } => {
+            let i = wallet.delete_transfers(blinded_utxo, txid, no_asset_only)?;
+            println!("{}", i);
+        }
+    }
+    Ok(())
+}
+
+fn handle_asset_command(
+    mut wallet: Wallet,
+    opts: Opts,
+    cmd: AssetCommand,
+) -> Result<(), Box<dyn Error + 'static>> {
+    match cmd {
+        AssetCommand::GetBalance { asset_id } => {
+            let b = wallet.get_asset_balance(asset_id)?;
+            println!("{}", serde_json::to_string(&b)?);
+        }
+        AssetCommand::Issue(IssueCommand::Rgb20 {
+            ticker,
+            name,
+            precision,
+            amounts,
+        }) => {
+            let online = Online {
+                id: 0,
+                electrum_url: opts.electrum_url.unwrap(),
+            };
+            let r = wallet.issue_asset_rgb20(
+                online,
+                ticker.to_uppercase(),
+                name,
+                precision,
+                amounts,
+            )?;
+            println!("{}", serde_json::to_string(&r)?);
+        }
+        AssetCommand::Issue(IssueCommand::Rgb121 {
+            name,
+            amounts,
+            description,
+            precision,
+            parent_id,
+            file_path,
+        }) => {
+            let online =
+                wallet.go_online(false, opts.electrum_url.expect("needs electrum_url option"))?;
+            let asset = wallet.issue_asset_rgb121(
+                online,
+                name,
+                description,
+                precision,
+                amounts,
+                parent_id,
+                file_path,
+            )?;
+            println!("{}", serde_json::to_string(&asset)?);
+        }
+        AssetCommand::List { filter_asset_types } => {
+            let asset = wallet.list_assets(filter_asset_types)?;
+            println!("{}", serde_json::to_string(&asset)?);
+        }
+        AssetCommand::GetMetadata { asset_id } => {
+            let online =
+                wallet.go_online(false, opts.electrum_url.expect("needs electrum_url option"))?;
+            let metadata = wallet.get_asset_metadata(online, asset_id)?;
+            println!("{}", serde_json::to_string(&metadata)?);
+        }
+    };
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn Error + 'static>> {
+    let opts = Opts::parse();
+
+    if !opts.data_dir.is_absolute() {
+        eprintln!("Please specify absolute path as data dir!");
+        std::process::exit(1);
+    }
+
+    let wallet_data = WalletData {
+        data_dir: opts.data_dir.to_str().unwrap().to_string(),
+        bitcoin_network: opts.network,
+        database_type: opts.db_type,
+        pubkey: opts.xpub.clone(),
+        mnemonic: opts.mnemonic.clone(),
+    };
+    let mut wallet = Wallet::new(wallet_data)?;
+
+    match opts.command.clone() {
+        Command::ListUnspents { settled_only } => {
+            assure_utxos_synced(
+                &mut wallet,
+                opts.electrum_url.expect("needs electrum_url option"),
+            );
+            let u = wallet.list_unspents(settled_only)?;
+            println!("{}", serde_json::to_string(&u)?);
+        }
+        Command::Blind {
+            amount,
+            asset_id,
+            duration_seconds,
+            consignment_endpoints,
+        } => {
+            assure_utxos_synced(
+                &mut wallet,
+                opts.electrum_url.expect("needs electrum_url option"),
+            );
+            let b = wallet.blind(asset_id, amount, duration_seconds, consignment_endpoints)?;
+            println!("{}", serde_json::to_string(&b)?);
+        }
+        Command::NativeWallet(NativeWalletCommand::GetAddress) => {
+            println!("{}", wallet.get_address())
+        }
+        Command::NativeWallet(NativeWalletCommand::Drain {
+            address,
+            destroy_assets,
+            fee_rate,
+        }) => {
+            let online =
+                wallet.go_online(false, opts.electrum_url.expect("needs electrum_url option"))?;
+            let fee_rate: f32 = (fee_rate * 1000) as f32;
+            let txid = wallet.drain_to(online, address, destroy_assets, fee_rate)?;
+            println!("{}", txid)
+        }
+        Command::Asset(cmd) => handle_asset_command(wallet, opts, cmd)?,
+        Command::Transfer(cmd) => handle_transfer_command(wallet, opts, cmd)?,
+    }
+    Ok(())
+}

--- a/cli/src/opts.rs
+++ b/cli/src/opts.rs
@@ -1,0 +1,269 @@
+use std::path::PathBuf;
+
+use clap::{Parser, Subcommand};
+use rgb_lib::{
+    wallet::{AssetType, DatabaseType},
+    BitcoinNetwork,
+};
+
+#[derive(Parser, Clone, PartialEq, Eq, Debug)]
+#[clap(name = "rgblib-tool", bin_name = "rgblib-tool", author, version, about)]
+pub struct Opts {
+    /// Data directory.
+    #[clap(short = 'd', long = "datadir")]
+    pub data_dir: PathBuf,
+
+    /// database type
+    #[clap(short = 't', long = "dbtype", default_value = "sqlite")]
+    pub db_type: DatabaseType,
+
+    /// master xpub for the wallet.
+    #[clap(short, long, required = true)]
+    pub xpub: String,
+
+    /// mnemonic for the wallet master private key.
+    #[clap(short, long)]
+    pub mnemonic: Option<String>,
+
+    /// Which bitcoin network to operate.
+    #[clap(
+        short = 'n',
+        long = "network",
+        default_value = "regtest",
+        global = true
+    )]
+    pub network: BitcoinNetwork,
+
+    /// Electrum url to connect. It is necessary only for an online operation.
+    #[clap(
+        long = "electrum-url",
+        alias = "electrs-url",
+        alias = "electrs",
+        alias = "electrum",
+        required = false,
+        global = true
+    )]
+    pub electrum_url: Option<String>,
+
+    #[clap(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand, Clone, Eq, PartialEq, Debug, amplify::Display)]
+pub enum Command {
+    #[display("list-unspents")]
+    ListUnspents {
+        #[display("settled_only: {0}")]
+        #[clap(short, long, action = clap::ArgAction::SetTrue)]
+        settled_only: bool,
+    },
+
+    #[display("asset")]
+    #[clap(subcommand)]
+    Asset(AssetCommand),
+
+    #[display("transfer")]
+    #[clap(subcommand)]
+    Transfer(TransferCommand),
+
+    /// Get necessary information to pass to a counterparty to ask funds from them.
+    #[display("blind")]
+    Blind {
+        /// Asset id that you want to receive
+        #[display("asset_id: {0}")]
+        #[clap(long = "asset-id", alias = "id")]
+        asset_id: Option<String>,
+
+        /// amount to blind,
+        #[display("amount: {0}")]
+        #[clap(short, long)]
+        amount: Option<u64>,
+
+        /// Duration until an expiry
+        #[display("duration_seconds: {0}")]
+        #[clap(short, long, alias = "duration")]
+        duration_seconds: Option<u32>,
+
+        /// List of endpoints that you want counterparty to send a response consignments.
+        #[display("consignment_endpoints: {0}")]
+        #[clap(short, long, required = true)]
+        consignment_endpoints: Vec<String>,
+    },
+
+    #[display("native-wallet")]
+    #[clap(subcommand)]
+    NativeWallet(NativeWalletCommand),
+}
+
+#[derive(Subcommand, Clone, Eq, PartialEq, Debug, amplify::Display)]
+pub enum NativeWalletCommand {
+    /// Get bitcoin address
+    #[display("get-address")]
+    GetAddress,
+
+    /// Send all utxos to an address (funds sweeping.)
+    /// By default it does not touch an UTXO which holds RGB-asset.
+    #[display("drain")]
+    Drain {
+        /// Address to send funds.
+        #[clap(short, long = "address", alias = "addr")]
+        address: String,
+
+        /// DANGEROUS: include UTXOs which holds RGB-asset.
+        /// This will destroy all your RGB assets.
+        #[clap(long, action = clap::ArgAction::SetTrue)]
+        destroy_assets: bool,
+
+        /// feerate for tx (sat/Kvb)
+        #[clap(short, long)]
+        fee_rate: u64,
+    },
+}
+
+#[derive(Subcommand, Clone, Eq, PartialEq, Debug, amplify::Display)]
+pub enum TransferCommand {
+    #[display("send")]
+    #[clap(alias = "transfer")]
+    Send {
+        /// Asset id to send
+        #[clap(long = "asset-id", alias = "id")]
+        asset_id: String,
+
+        /// destination blinded_utxo
+        #[clap(long)]
+        blinded_utxo: String,
+
+        /// Amount to send
+        #[clap(long)]
+        amount: u64,
+
+        /// List of endpoints that you want send the consignment data.
+        #[display("consignment_endpoints: {0}")]
+        #[clap(short, long, required = true)]
+        consignment_endpoints: Vec<String>,
+
+        /// If donation is set, It will broadcast the tx without waiting counterparty's ACK.
+        #[clap(short, long, action = clap::ArgAction::SetTrue)]
+        donation: bool,
+
+        /// feerate for tx (sat/Kvb)
+        #[clap(short, long)]
+        fee_rate: u64,
+    },
+    #[display("list ...")]
+    List {
+        #[clap(long = "asset_id", alias = "id")]
+        asset_id: String,
+    },
+    #[display("fail")]
+    Fail {
+        /// If this option is specified, it works only for specific transfer txo.
+        #[clap(long, conflicts_with = "txid")]
+        blinded_utxo: Option<String>,
+
+        /// If this option is specified, it works only for specific transfer tx.
+        #[clap(long, conflicts_with = "blinded-utxo")]
+        txid: Option<String>,
+
+        /// Fail only transfers those not associated to any asset.
+        #[clap(long, action = clap::ArgAction::SetTrue)]
+        no_asset_only: bool,
+    },
+    Delete {
+        /// If this option is specified, it works only for specific transfer txo.
+        #[clap(long, conflicts_with = "txid")]
+        blinded_utxo: Option<String>,
+
+        /// If this option is specified, it works only for specific transfer tx.
+        #[clap(long, conflicts_with = "blinded-utxo")]
+        txid: Option<String>,
+
+        /// Delete only transfers those not associated to any asset.
+        #[clap(long, action = clap::ArgAction::SetTrue)]
+        no_asset_only: bool,
+    },
+}
+
+#[derive(Subcommand, Clone, Eq, PartialEq, Debug, amplify::Display)]
+pub enum AssetCommand {
+    #[display("issue")]
+    #[clap(subcommand)]
+    Issue(IssueCommand),
+
+    #[display("list ...")]
+    List {
+        #[clap(short = 't', long = "asset_type", alias = "asset")]
+        filter_asset_types: Vec<AssetType>,
+    },
+
+    /// Get balance for specific asset
+    #[display("get-balance")]
+    GetBalance {
+        #[display("asset_id: {0}")]
+        #[clap(long = "asset-id", alias = "id")]
+        asset_id: String,
+    },
+
+    /// Get metadata for asset
+    GetMetadata {
+        #[display("asset_id: {0}")]
+        #[clap(long = "asset-id", alias = "id")]
+        asset_id: String,
+    },
+}
+
+#[derive(Subcommand, Clone, Eq, PartialEq, Debug, amplify::Display)]
+pub enum IssueCommand {
+    #[display("rgb20")]
+    Rgb20 {
+        /// Asset name
+        #[display("name: {0}")]
+        #[clap(short, long, required = true)]
+        name: String,
+
+        /// Ticker symbol for the asset. It will be converted to uppercase.
+        #[display("ticker: {0}")]
+        #[clap(short, long, required = true)]
+        ticker: String,
+
+        /// amounts to issue.
+        #[display("amounts: {0}")]
+        #[clap(short, long, required = true)]
+        amounts: Vec<u64>,
+
+        /// Precision (amount divisibility) of the asset.
+        #[display("precision: {0}")]
+        #[clap(short, long, default_value_t = 1u8)]
+        precision: u8,
+    },
+
+    #[display("rgb121")]
+    Rgb121 {
+        /// Asset name
+        #[display("name: {0}")]
+        #[clap(short, long, required = true)]
+        name: String,
+
+        /// amounts to issue.
+        #[display("amounts: {0}")]
+        #[clap(short, long, required = true)]
+        amounts: Vec<u64>,
+
+        #[display("description")]
+        #[clap(short, long)]
+        description: Option<String>,
+
+        /// Precision (amount divisibility) of the asset.
+        #[display("precision: {0}")]
+        #[clap(short, long, default_value_t = 1u8)]
+        precision: u8,
+
+        #[display("parent_id: {0}")]
+        #[clap(long)]
+        parent_id: Option<String>,
+
+        #[display("file_path: {0}")]
+        #[clap(short, long)]
+        file_path: Option<String>,
+    },
+}

--- a/cli/src/wallet_helpers.rs
+++ b/cli/src/wallet_helpers.rs
@@ -1,0 +1,10 @@
+use rgb_lib::Wallet;
+
+pub fn assure_utxos_synced(wallet: &mut Wallet, electrum_url: String) {
+    let online = wallet.go_online(false, electrum_url).unwrap();
+    match wallet.create_utxos(online, true, None, None, 10.0001) {
+        Err(rgb_lib::Error::AllocationsAlreadyAvailable) => (),
+        Ok(_num) => (),
+        Err(x) => panic!("{}", x.to_string()),
+    }
+}

--- a/src/database/enums.rs
+++ b/src/database/enums.rs
@@ -32,13 +32,25 @@ pub enum ConsignmentEndpointProtocol {
 }
 
 /// The status of a [`crate::wallet::Transfer`]
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Ord, PartialOrd, EnumIter, DeriveActiveEnum)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Ord,
+    PartialOrd,
+    EnumIter,
+    DeriveActiveEnum,
+    Serialize,
+    Deserialize,
+)]
 #[sea_orm(rs_type = "u16", db_type = "Integer")]
 pub enum TransferStatus {
     /// Waiting for the counterparty to take action
     #[sea_orm(num_value = 1)]
     WaitingCounterparty = 1,
-    /// Waiting for the transfer transcation to be confirmed
+    /// Waiting for the transfer transaction to be confirmed
     #[sea_orm(num_value = 2)]
     WaitingConfirmations = 2,
     /// Settled transfer, this status is final

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,9 @@
 #[macro_use]
 extern crate slog;
 
+#[macro_use]
+extern crate amplify;
+
 pub(crate) mod api;
 pub(crate) mod database;
 pub(crate) mod error;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -27,16 +27,37 @@ const TIMESTAMP_FORMAT: &[time::format_description::FormatItem] = time::macros::
 const LOG_FILE: &str = "log";
 
 /// Supported Bitcoin networks
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, amplify::Display)]
 pub enum BitcoinNetwork {
     /// Bitcoin's mainnet
+    #[display("mainnet")]
     Mainnet,
+
     /// Bitcoin's testnet
+    #[display("testnet")]
     Testnet,
+
     /// Bitcoin's signet
+    #[display("signet")]
     Signet,
+
     /// Bitcoin's regtest
+    #[display("regtest")]
     Regtest,
+}
+
+impl FromStr for BitcoinNetwork {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "mainnet" => Ok(Self::Mainnet),
+            "testnet" => Ok(Self::Testnet),
+            "signet" => Ok(Self::Signet),
+            "regtest" => Ok(Self::Regtest),
+            x => Err(format!("unknown network {}", x)),
+        }
+    }
 }
 
 impl From<BdkNetwork> for BitcoinNetwork {


### PR DESCRIPTION
While I was working on other stuffs using rgb-lib, I wanted to populate my db with test data.
Doing so will be easier if I could use rgb-lib wallet from command line, thus adding small wrapper crate `cli` .

