### PR TITLE
Fix migration version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "rgb-lib-migration"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "async-std",
  "sea-orm-migration",

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rgb-lib-migration"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 authors = ["Zoe Faltibà <zoefaltiba@gmail.com>", "Nicola Busanello <nicola.busanello@gmail.com>"]
 edition = "2021"
 rust-version = "1.67"


### PR DESCRIPTION
Recent changes to DB are not applied to current `rgb-lib-migration` version.