### PR TITLE
Add  c-ffi binding for PSBT signing

### DIFF
--- a/bindings/c-ffi/src/lib.rs
+++ b/bindings/c-ffi/src/lib.rs
@@ -297,6 +297,14 @@ pub extern "C" fn rgblib_send_btc(
 }
 
 #[no_mangle]
+pub extern "C" fn rgblib_sign_psbt(
+    wallet: &COpaqueStruct,
+    unsigned_psbt: *const c_char,
+) -> CResultString {
+    sign_psbt(wallet, unsigned_psbt).into()
+}
+
+#[no_mangle]
 pub extern "C" fn rgblib_sync(wallet: &COpaqueStruct, online: &COpaqueStruct) -> CResultString {
     sync(wallet, online).into()
 }

--- a/bindings/c-ffi/src/utils.rs
+++ b/bindings/c-ffi/src/utils.rs
@@ -473,6 +473,15 @@ pub(crate) fn send_btc(
     Ok(res)
 }
 
+pub(crate) fn sign_psbt(
+    wallet: &COpaqueStruct,
+    unsigned_psbt: *const c_char,
+) -> Result<String, Error> {
+    let wallet = Wallet::from_opaque(wallet)?;
+    let unsigned_psbt = ptr_to_string(unsigned_psbt);
+    Ok(wallet.sign_psbt(unsigned_psbt, None)?)
+}
+
 pub(crate) fn sync(wallet: &COpaqueStruct, online: &COpaqueStruct) -> Result<(), Error> {
     let wallet = Wallet::from_opaque(wallet)?;
     let online = Online::from_opaque(online)?;


### PR DESCRIPTION
### Notes
This PR adds a C-compatible FFI function, `rgblib_sign_psbt`, which exposes the internal `sign_psbt` logic 
The new binding allows`rgb-lib-nodejs` to invoke PSBT signing func via FFI