### PR TITLE
Add invoice_data function to C FFI bindings

### DIFF
--- a/bindings/c-ffi/src/lib.rs
+++ b/bindings/c-ffi/src/lib.rs
@@ -243,6 +243,11 @@ pub extern "C" fn rgblib_inflate(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn rgblib_invoice_data(invoice_string: *const c_char) -> CResultString {
+    invoice_data(invoice_string).into()
+}
+
+#[unsafe(no_mangle)]
 pub extern "C" fn rgblib_issue_asset_cfa(
     wallet: &COpaqueStruct,
     name: *const c_char,

--- a/bindings/c-ffi/src/utils.rs
+++ b/bindings/c-ffi/src/utils.rs
@@ -380,6 +380,12 @@ pub(crate) fn inflate(
     Ok(serde_json::to_string(&res)?)
 }
 
+pub(crate) fn invoice_data(invoice_string: *const c_char) -> Result<String, Error> {
+    let invoice_string = ptr_to_string(invoice_string);
+    let invoice = rgb_lib::wallet::Invoice::new(invoice_string)?;
+    Ok(serde_json::to_string(&invoice.invoice_data())?)
+}
+
 pub(crate) fn issue_asset_cfa(
     wallet: &COpaqueStruct,
     name: *const c_char,


### PR DESCRIPTION
This PR adds new extern C function rgblib_invoice_data, to the C FFI bindings, allowing for the retrieval of invoice data from a given invoice string. 