### PR TITLE
Switch BDK persistence from file store to SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,14 +383,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "bdk_file_store"
-version = "0.22.0"
+name = "bdk_sqlite"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7b9a98edb58d02b601239832674a9ca9f1465e08e1dd1fac3a0e34004372406"
+checksum = "8f2f05ffd2ec7af55c049fc4f2b5d55fdfc51f0e04a0f445f08409b0a3f4efcd"
 dependencies = [
- "bdk_core",
- "bincode",
- "serde",
+ "bdk_chain",
+ "bdk_wallet",
+ "sqlx",
 ]
 
 [[package]]
@@ -400,7 +400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1284fb23acc3e3022673712b55f4d5ce7e38aadc2c49bbef830dc3935f0a3289"
 dependencies = [
  "bdk_chain",
- "bdk_file_store",
  "bip39",
  "bitcoin",
  "miniscript",
@@ -426,15 +425,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "serde",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
  "serde",
 ]
 
@@ -3230,6 +3220,7 @@ dependencies = [
  "base64 0.22.1",
  "bdk_electrum",
  "bdk_esplora",
+ "bdk_sqlite",
  "bdk_wallet",
  "biscuit-auth",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,10 @@ members = [".", "migration"]
 base64 = { version = "0.22.1", default-features = false, features = [
     "std",
 ] }
+bdk_sqlite = { version = "0.6.0", default-features = false, features = [
+    "wallet",
+] }
 bdk_wallet = { version = "=3.1.0", default-features = false, features = [
-    "file_store",
     "keys-bip39",
     "std",
 ] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -888,32 +888,24 @@ impl From<rgbinvoice::TransportParseError> for Error {
     }
 }
 
-impl From<bdk_wallet::file_store::StoreErrorWithDump<ChangeSet>> for Error {
-    fn from(e: bdk_wallet::file_store::StoreErrorWithDump<ChangeSet>) -> Self {
+impl From<bdk_sqlite::Error> for Error {
+    fn from(e: bdk_sqlite::Error) -> Self {
         Error::IO {
             details: e.to_string(),
         }
     }
 }
 
-impl From<bdk_wallet::FileStoreError> for Error {
-    fn from(e: bdk_wallet::FileStoreError) -> Self {
+impl From<bdk_wallet::CreateWithPersistError<bdk_sqlite::Error>> for Error {
+    fn from(e: bdk_wallet::CreateWithPersistError<bdk_sqlite::Error>) -> Self {
         Error::IO {
             details: e.to_string(),
         }
     }
 }
 
-impl From<bdk_wallet::CreateWithPersistError<bdk_wallet::FileStoreError>> for Error {
-    fn from(e: bdk_wallet::CreateWithPersistError<bdk_wallet::FileStoreError>) -> Self {
-        Error::IO {
-            details: e.to_string(),
-        }
-    }
-}
-
-impl From<bdk_wallet::LoadWithPersistError<bdk_wallet::FileStoreError>> for Error {
-    fn from(e: bdk_wallet::LoadWithPersistError<bdk_wallet::FileStoreError>) -> Self {
+impl From<bdk_wallet::LoadWithPersistError<bdk_sqlite::Error>> for Error {
+    fn from(e: bdk_wallet::LoadWithPersistError<bdk_sqlite::Error>) -> Self {
         match e {
             bdk_wallet::LoadWithPersistError::InvalidChangeSet(
                 bdk_wallet::LoadError::Mismatch(bdk_wallet::LoadMismatch::Genesis { .. }),
@@ -991,31 +983,21 @@ mod tests {
         assert_matches!(err, Error::Internal { details } if !details.is_empty());
 
         // LoadWithPersistError error
-        let err = bdk_wallet::LoadWithPersistError::Persist(bdk_wallet::FileStoreError::Write(
-            std::io::Error::new(std::io::ErrorKind::PermissionDenied, "no access"),
+        let err = bdk_wallet::LoadWithPersistError::Persist(bdk_sqlite::Error::FromInt(
+            u8::try_from(300u32).unwrap_err(),
         ));
         let err = Error::from(err);
         assert_matches!(err, Error::IO { details } if !details.is_empty());
 
         // CreateWithPersistError error
-        let err = bdk_wallet::CreateWithPersistError::Persist(bdk_wallet::FileStoreError::Write(
-            std::io::Error::new(std::io::ErrorKind::PermissionDenied, "no access"),
+        let err = bdk_wallet::CreateWithPersistError::Persist(bdk_sqlite::Error::FromInt(
+            u8::try_from(300u32).unwrap_err(),
         ));
         let err = Error::from(err);
         assert_matches!(err, Error::IO { details } if !details.is_empty());
 
-        // FileStoreError error
-        let err = bdk_wallet::FileStoreError::Write(std::io::Error::new(
-            std::io::ErrorKind::PermissionDenied,
-            "no access",
-        ));
-        let err = Error::from(err);
-        assert_matches!(err, Error::IO { details } if !details.is_empty());
-
-        // StoreErrorWithDump error
-        let err = bdk_wallet::file_store::StoreErrorWithDump::<ChangeSet>::from(
-            std::io::Error::new(std::io::ErrorKind::PermissionDenied, "no access"),
-        );
+        // bdk_sqlite::Error error
+        let err = bdk_sqlite::Error::FromInt(u8::try_from(300u32).unwrap_err());
         let err = Error::from(err);
         assert_matches!(err, Error::IO { details } if !details.is_empty());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,10 +160,11 @@ use bdk_esplora::{
         BlockingClient as EsploraClient, Builder as EsploraBuilder, Error as EsploraError,
     },
 };
+use bdk_sqlite::Store as BdkStore;
 #[cfg(feature = "esplora")]
 use bdk_wallet::bitcoin::Txid;
 use bdk_wallet::{
-    ChangeSet, KeychainKind, LocalOutput, PersistedWallet, SignOptions, Wallet as BdkWallet,
+    KeychainKind, LocalOutput, PersistedWallet, SignOptions, Wallet as BdkWallet,
     bitcoin::{
         Address as BdkAddress, Amount as BdkAmount, BlockHash, Network as BdkNetwork, NetworkKind,
         OutPoint, OutPoint as BdkOutPoint, ScriptBuf, TxOut,
@@ -174,7 +175,6 @@ use bdk_wallet::{
     },
     chain::{CanonicalizationParams, ChainPosition},
     descriptor::Segwitv0,
-    file_store::Store,
     keys::{
         DerivableKey, DescriptorKey,
         DescriptorKey::{Public, Secret},

--- a/src/wallet/core.rs
+++ b/src/wallet/core.rs
@@ -4,7 +4,7 @@
 
 use super::*;
 
-const BDK_DB_NAME: &str = "bdk_db";
+const BDK_DB_NAME: &str = "bdk_db_sqlite";
 
 pub(crate) const NUM_KNOWN_SCHEMAS: usize = 4;
 
@@ -207,8 +207,8 @@ pub struct WalletInternals {
     pub(crate) _logger_guard: AsyncGuard,
     pub(crate) database: Arc<RgbLibDatabase>,
     pub(crate) wallet_dir: PathBuf,
-    pub(crate) bdk_wallet: PersistedWallet<Store<ChangeSet>>,
-    pub(crate) bdk_database: Store<ChangeSet>,
+    pub(crate) bdk_wallet: PersistedWallet<BdkStore>,
+    pub(crate) bdk_database: BdkStore,
     #[cfg(any(feature = "electrum", feature = "esplora"))]
     pub(crate) online_data: Option<OnlineData>,
 }
@@ -260,7 +260,7 @@ pub(crate) fn setup_bdk<P: AsRef<Path>>(
     desc_vanilla: String,
     watch_only: bool,
     bdk_network: BdkNetwork,
-) -> Result<(PersistedWallet<Store<ChangeSet>>, Store<ChangeSet>), Error> {
+) -> Result<(PersistedWallet<BdkStore>, BdkStore), Error> {
     let chain_net: ChainNet = wallet_data.bitcoin_network.into();
     let mut wallet_params = BdkWallet::load()
         .descriptor(KeychainKind::External, Some(desc_colored.clone()))
@@ -275,13 +275,16 @@ pub(crate) fn setup_bdk<P: AsRef<Path>>(
         BDK_DB_NAME.to_string()
     };
     let bdk_db_path = wallet_dir.as_ref().join(bdk_db_name);
-    let (mut bdk_database, _) =
-        Store::<ChangeSet>::load_or_create(BDK_DB_NAME.as_bytes(), bdk_db_path)?;
-    let bdk_wallet = match wallet_params.load_wallet(&mut bdk_database)? {
+    let bdk_db_url = format!("sqlite:{}", adjust_canonicalization(bdk_db_path));
+    let mut bdk_database = block_on(BdkStore::new(&bdk_db_url))?;
+    // schema migrations are applied automatically when the wallet is loaded
+    let bdk_wallet = match block_on(wallet_params.load_wallet_async(&mut bdk_database))? {
         Some(wallet) => wallet,
-        None => BdkWallet::create(desc_colored, desc_vanilla)
-            .network(bdk_network)
-            .create_wallet(&mut bdk_database)?,
+        None => block_on(
+            BdkWallet::create(desc_colored, desc_vanilla)
+                .network(bdk_network)
+                .create_wallet_async(&mut bdk_database),
+        )?,
     };
     Ok((bdk_wallet, bdk_database))
 }
@@ -320,20 +323,15 @@ pub trait WalletCore {
 
     fn internals_mut(&mut self) -> &mut WalletInternals;
 
-    fn bdk_wallet(&self) -> &PersistedWallet<Store<ChangeSet>> {
+    fn bdk_wallet(&self) -> &PersistedWallet<BdkStore> {
         &self.internals().bdk_wallet
     }
 
-    fn bdk_wallet_mut(&mut self) -> &mut PersistedWallet<Store<ChangeSet>> {
+    fn bdk_wallet_mut(&mut self) -> &mut PersistedWallet<BdkStore> {
         &mut self.internals_mut().bdk_wallet
     }
 
-    fn bdk_wallet_db_mut(
-        &mut self,
-    ) -> (
-        &mut PersistedWallet<Store<ChangeSet>>,
-        &mut Store<ChangeSet>,
-    ) {
+    fn bdk_wallet_db_mut(&mut self) -> (&mut PersistedWallet<BdkStore>, &mut BdkStore) {
         let internals_mut = self.internals_mut();
         (
             &mut internals_mut.bdk_wallet,
@@ -494,7 +492,7 @@ pub trait WalletCore {
             .map_err(|e| Error::FailedBdkSync {
                 details: e.to_string(),
             })?;
-        bdk_wallet.persist(bdk_db)?;
+        block_on(bdk_wallet.persist_async(bdk_db))?;
 
         if matches!(options.keychain, SyncKeychain::Colored) {
             self.update_db_colored_txos_from_bdk(txn, include_spent)?;

--- a/src/wallet/indexer.rs
+++ b/src/wallet/indexer.rs
@@ -196,9 +196,7 @@ impl Indexer {
 
     pub(crate) fn populate_tx_cache(
         &self,
-        #[cfg_attr(feature = "esplora", allow(unused))] bdk_wallet: &PersistedWallet<
-            Store<ChangeSet>,
-        >,
+        #[cfg_attr(feature = "esplora", allow(unused))] bdk_wallet: &PersistedWallet<BdkStore>,
     ) {
         match self {
             #[cfg(feature = "electrum")]

--- a/src/wallet/multisig.rs
+++ b/src/wallet/multisig.rs
@@ -240,7 +240,7 @@ impl WalletCore for MultisigWallet {
         reveal(KeychainKind::Internal, response.internal);
         reveal(KeychainKind::External, response.external);
         if persist {
-            bdk_wallet.persist(bdk_database)?;
+            block_on(bdk_wallet.persist_async(bdk_database))?;
         }
         // sync UTXOs
         self.sync_bdk_and_db_txos(txn, options, include_spent)
@@ -267,7 +267,7 @@ impl WalletOffline for MultisigWallet {
             bdk_wallet.reveal_next_address(keychain);
         }
         let first_address = bdk_wallet.peek_address(keychain, start_index).address;
-        bdk_wallet.persist(bdk_database)?;
+        block_on(bdk_wallet.persist_async(bdk_database))?;
         Ok(first_address)
     }
 }

--- a/src/wallet/offline.rs
+++ b/src/wallet/offline.rs
@@ -1234,7 +1234,7 @@ pub trait WalletOffline: WalletBackup {
     ) -> Result<BdkAddress, Error> {
         let (bdk_wallet, bdk_db) = self.bdk_wallet_db_mut();
         let address = bdk_wallet.reveal_next_address(keychain).address;
-        bdk_wallet.persist(bdk_db)?;
+        block_on(bdk_wallet.persist_async(bdk_db))?;
         Ok(address)
     }
 

--- a/src/wallet/online.rs
+++ b/src/wallet/online.rs
@@ -99,7 +99,7 @@ pub trait WalletOnline: WalletOffline {
         let seen_at = now().unix_timestamp() as u64;
         let (bdk_wallet, bdk_db) = self.bdk_wallet_db_mut();
         bdk_wallet.apply_unconfirmed_txs([(tx.clone(), seen_at)]);
-        bdk_wallet.persist(bdk_db)?;
+        block_on(bdk_wallet.persist_async(bdk_db))?;
 
         // promote any newly-known colored UTXOs (e.g. the change output) from
         // exists=false to exists=true in the rgb_lib DB

--- a/src/wallet/test/go_online.rs
+++ b/src/wallet/test/go_online.rs
@@ -174,7 +174,7 @@ fn consistency_check_fail_bitcoins() {
         .unwrap();
     {
         let (bdk_wallet, bdk_database) = party_empty.wallet.bdk_wallet_db_mut();
-        bdk_wallet.persist(bdk_database).unwrap();
+        block_on(bdk_wallet.persist_async(bdk_database)).unwrap();
     }
     let mut rcv_party = get_funded_party!();
     party_empty.drain_to(&rcv_party.get_address());
@@ -266,7 +266,7 @@ fn consistency_check_fail_utxos() {
         .unwrap();
     {
         let (bdk_wallet, bdk_database) = party_empty.wallet.bdk_wallet_db_mut();
-        bdk_wallet.persist(bdk_database).unwrap();
+        block_on(bdk_wallet.persist_async(bdk_database)).unwrap();
     }
     let mut rcv_party = get_funded_party!();
     party_empty.drain_to(&rcv_party.get_address());


### PR DESCRIPTION
`rgb-lib` currently persists BDK wallet data with `bdk_file_store`, which upstream explicitly [documents](https://docs.rs/bdk_file_store/latest/bdk_file_store/) as unfit for production:

> `bdk_file_store` is a development/testing database. It does not natively support backwards compatible BDK version upgrades so should not be used in production.

This already caused breakage: the file store format changed in the BDK upgrade from 2.0 to 3.0, leaving existing databases unreadable. SQLite is the production-oriented, upgrade-migratable backend.

This PR moves BDK persistence to [`bdk_sqlite`](https://github.com/bitcoindevkit/bdk-sqlite) (BDK's `sqlx`-based SQLite store). Using it rather than `bdk_wallet`'s built-in `rusqlite` feature also avoids a native-library conflict: `rusqlite` and `rgb-lib`'s existing `sea-orm`/`sqlx` stack pull different `libsqlite3-sys` versions, and two crates linking `sqlite3` can't coexist. `bdk_sqlite` shares `sea-orm`'s `sqlx`, so the dependency graph resolves cleanly.

### Note on existing wallets

This switch (like the BDK 2.0 to 3.0 upgrade before it) is not backwards compatible: existing BDK file-store databases are not read, so on first open the wallet creates a fresh SQLite store and repopulates via the normal scan. This is unavoidable when changing persistence backends and is the motivation for moving to a properly migratable one going forward.