### PR TITLE
Multisig hub catch-up panics when the operation's change UTXO was spent while the wallet was behind

### DIFF
--- a/src/wallet/test/multisig/mod.rs
+++ b/src/wallet/test/multisig/mod.rs
@@ -1752,3 +1752,222 @@ fn send_to_oneself() {
         (AMOUNT_SMALL, AMOUNT_SMALL, AMOUNT_SMALL),
     );
 }
+#[cfg(feature = "electrum")]
+#[test]
+#[serial]
+fn sync_with_hub_replay_survives_inflation_change() {
+    initialize();
+    op_counter_reset();
+
+    let bitcoin_network = BitcoinNetwork::Regtest;
+    let threshold_colored = 2;
+    let threshold_vanilla = 2;
+    let random_str: String = rand::rng()
+        .sample_iter(&Alphanumeric)
+        .take(6)
+        .map(char::from)
+        .collect();
+
+    // multisig wallet keys
+    let wlt_1_keys = generate_keys(bitcoin_network, WitnessVersion::Taproot);
+    let wlt_2_keys = generate_keys(bitcoin_network, WitnessVersion::Taproot);
+    let wlt_3_keys = generate_keys(bitcoin_network, WitnessVersion::Taproot);
+
+    // cosigners
+    let cosigners = vec![
+        Cosigner::from_keys(&wlt_1_keys, None),
+        Cosigner::from_keys(&wlt_2_keys, None),
+        Cosigner::from_keys(&wlt_3_keys, None),
+    ];
+    let cosigner_xpubs: Vec<String> = cosigners
+        .iter()
+        .map(|c| c.account_xpub_colored.clone())
+        .collect();
+
+    // biscuit token setup
+    let root_keypair = KeyPair::new();
+    let root_public_key = root_keypair.public();
+    let mut cosigner_tokens = vec![];
+    for cosigner_xpub in &cosigner_xpubs {
+        cosigner_tokens.push(create_token(
+            &root_keypair,
+            Role::Cosigner(cosigner_xpub.clone()),
+            None,
+        ));
+    }
+
+    // hub setup
+    write_hub_config(
+        &cosigner_xpubs,
+        threshold_colored,
+        threshold_vanilla,
+        root_public_key.to_bytes_hex(),
+        None,
+    );
+    restart_multisig_hub();
+
+    // multisig wallets
+    let multisig_wlt_keys =
+        MultisigKeys::new(cosigners.clone(), threshold_colored, threshold_vanilla);
+    let mut wlt_1_multisig = get_test_ms_wallet(&multisig_wlt_keys, format!("{random_str}_1"));
+    let wlt_1_multisig_online = ms_go_online(&mut wlt_1_multisig, &cosigner_tokens[0]);
+    let mut wlt_2_multisig = get_test_ms_wallet(&multisig_wlt_keys, format!("{random_str}_2"));
+    let wlt_2_multisig_online = ms_go_online(&mut wlt_2_multisig, &cosigner_tokens[1]);
+    let mut wlt_3_multisig = get_test_ms_wallet(&multisig_wlt_keys, format!("{random_str}_3"));
+    let wlt_3_multisig_online = ms_go_online(&mut wlt_3_multisig, &cosigner_tokens[2]);
+
+    // singlesig wallets (for signing)
+    let wlt_1_singlesig = get_test_wallet_with_keys(&wlt_1_keys);
+    let wlt_2_singlesig = get_test_wallet_with_keys(&wlt_2_keys);
+    let wlt_3_singlesig = get_test_wallet_with_keys(&wlt_3_keys);
+
+    // multisig parties
+    let mut wlt_1 = ms_party!(
+        &wlt_1_singlesig,
+        &mut wlt_1_multisig,
+        wlt_1_multisig_online,
+        &cosigner_xpubs[0]
+    );
+    let mut wlt_2 = ms_party!(
+        &wlt_2_singlesig,
+        &mut wlt_2_multisig,
+        wlt_2_multisig_online,
+        &cosigner_xpubs[1]
+    );
+    let mut wlt_3 = ms_party!(
+        &wlt_3_singlesig,
+        &mut wlt_3_multisig,
+        wlt_3_multisig_online,
+        &cosigner_xpubs[2]
+    );
+
+    // fund wallet 1
+    send_sats_to_address(wlt_1.get_address(), Some(50_000));
+    mine(false);
+
+    // wlt_3 stays behind for the whole flow - the state of a cosigner that
+    // fell behind, or of one whose wallet was rebuilt and has to catch up.
+    println!("\n=== create UTXOs (wlt_1 + wlt_2) ===");
+    // Exactly two: the IFA genesis occupies one UTXO for the fungible amount
+    // and one for the inflation rights, leaving no empty output of this batch.
+    let op_init = wlt_1.create_utxos_init(false, Some(2), Some(1000), FEE_RATE);
+    operation_complete::<CreateUtxosHandler>(
+        op_init.operation_idx,
+        &mut [&mut wlt_1, &mut wlt_2],
+        &mut [],
+        &mut [],
+        true,
+    );
+    mine(false);
+
+    println!("\n=== issue IFA with inflation rights (wlt_1 + wlt_2) ===");
+    let IssuedAsset::Ifa(ifa_asset) = issue_asset(
+        &mut wlt_1,
+        &mut [&mut wlt_2],
+        AssetSchema::Ifa,
+        Some(&[600]),
+        Some(&[1000]),
+    ) else {
+        unreachable!()
+    };
+
+    println!("\n=== wlt_3 catches up through the issuance, then goes dark ===");
+    // The lagging cosigner must know the inflation's input UTXOs (they are
+    // unspent right now, so this sync records them) but must miss the window
+    // in which the change target is created AND spent. A wallet that never
+    // synced would be rescued by the replay's own FastSync backfill; a wallet
+    // that synced up to here is not.
+    wlt_3.sync_to_head();
+
+    println!("\n=== create UTXOs round 2 - the only empties left for the inflation ===");
+    // The genesis occupies every round-1 output, so inflation 1 must place its
+    // rights change on a round-2 output. Replaying the issuance materializes
+    // txo rows for the round-1 tx (its consignment anchors there), but nothing
+    // replays a create-utxos tx - round-2 outputs stay unknown to a
+    // catching-up wallet.
+    let cu2 = wlt_1.create_utxos_init(false, Some(5), Some(1000), FEE_RATE);
+    operation_complete::<CreateUtxosHandler>(
+        cu2.operation_idx,
+        &mut [&mut wlt_1, &mut wlt_2],
+        &mut [],
+        &mut [],
+        true,
+    );
+    mine(false);
+    let cu2_txid = Psbt::from_str(&cu2.psbt).unwrap().get_txid().to_string();
+
+    println!("\n=== inflation 1 (wlt_1 + wlt_2) - the operation wlt_3 will replay ===");
+    let inflate_op = wlt_1.inflate_init(&ifa_asset.asset_id, &[25]);
+    operation_complete::<InflateHandler>(
+        inflate_op.operation_idx,
+        &mut [&mut wlt_1, &mut wlt_2],
+        &mut [],
+        &mut [],
+        true,
+    );
+    settle_transfer(
+        &mut [&mut wlt_1, &mut wlt_2],
+        &mut [] as &mut [&mut MultisigParty],
+        Some(&ifa_asset.asset_id),
+        None,
+        Some(&inflate_op.psbt),
+        false,
+    );
+
+    println!("\n=== inflation 2 spends inflation 1's rights change ===");
+    // The remaining inflation rights ride the UTXO inflation 1 assigned its
+    // change to; inflation 2 must consume it. That is the load-bearing part:
+    // a spent outpoint is not restored by a chain sync, so the lagging
+    // wallet's replay of inflation 1 has no txo row to find.
+    let inflate_op_2 = wlt_1.inflate_init(&ifa_asset.asset_id, &[26]);
+    operation_complete::<InflateHandler>(
+        inflate_op_2.operation_idx,
+        &mut [&mut wlt_1, &mut wlt_2],
+        &mut [],
+        &mut [],
+        true,
+    );
+    settle_transfer(
+        &mut [&mut wlt_1, &mut wlt_2],
+        &mut [] as &mut [&mut MultisigParty],
+        Some(&ifa_asset.asset_id),
+        None,
+        Some(&inflate_op_2.psbt),
+        false,
+    );
+
+    println!("\n=== inflation 1 operation data, as any catch-up will read it ===");
+    let (_, files) = wlt_1.get_op_and_files(inflate_op.operation_idx);
+    let data_file = files
+        .iter()
+        .find(|f| matches!(f.r#type, FileType::OperationData))
+        .unwrap();
+    let info: InfoBatchTransfer =
+        serde_json::from_reader(fs::File::open(&data_file.filepath).unwrap()).unwrap();
+    println!(
+        "btc_change={:?} change_utxo_outpoint={:?}",
+        info.btc_change, info.change_utxo_outpoint
+    );
+    // The steering must have worked: no btc change (sub-dust remainder) and
+    // the RGB change assigned to an output of create-utxos round 2.
+    assert!(
+        info.btc_change.is_none(),
+        "expected a no-btc-change inflation"
+    );
+    assert_eq!(
+        info.change_utxo_outpoint.as_ref().unwrap().txid,
+        cu2_txid,
+        "expected the inflation change on a create-utxos round 2 output"
+    );
+
+    println!("\n=== wlt_3 catches up over the whole history ===");
+    // This is the library's own recovery path; it must complete. Today it
+    // panics at online.rs `.expect("should exist")` replaying inflation 1.
+    wlt_3.sync_to_head();
+
+    check_asset_balance(
+        &[&wlt_1, &wlt_2, &wlt_3],
+        &ifa_asset.asset_id,
+        (651, 651, 651),
+    );
+}


### PR DESCRIPTION
## Summary

A multisig cosigner catching up on hub history panics in `get_change_utxo_idx` when the replayed operation assigned its RGB change to a UTXO that was created **and** spent while that cosigner was not syncing:

```
thread '…' panicked at src/wallet/online.rs:2934:36: should exist
```

Through FFI bindings the panic aborts the host process, and since operations are processed sequentially the same operation is replayed on every restart: the wallet crash-loops with no recovery short of manual DB surgery. We hit this in production-like use (a wallet restored from an older copy catching up on hub history) on `v0.3.0-beta.28`; `master` panics identically - the test in this PR is red on current `master`.

## Mechanism

`get_change_utxo_idx` treats its two arms asymmetrically:

- the `btc_change` arm tolerates a missing TXO and inserts a placeholder row (`exists: false`);
- the `change_utxo_outpoint` arm does a bare `txn.get_txo(outpoint)?.expect("should exist")` (online.rs:2934).

Nothing guarantees that row exists:

- every regular sync writes TXO rows with `include_spent = false` - unspent only - so an outpoint created *and* spent inside the wallet's offline window is never backfilled;
- the spent-assignments loops in `save_transfers` have a rescue path (`FastSync` + `include_spent = true`) for missing **input** TXOs, but the change outpoint is looked up without any rescue;
- a create-utxos replay materializes no TXO rows at all.

A wallet that never synced is silently rescued - its missing inputs trigger the spent-assignments backfill, which happens to also insert the change TXO. A wallet that was merely *behind* (the realistic recovery case: it knows the inputs from before it went dark, so the rescue never fires) panics.

## Reproducer

`sync_with_hub_replay_survives_inflation_change` (2-of-3 multisig, IFA):

1. create-utxos round 1: exactly 2 outputs - the genesis occupies both;
2. issue IFA (600 fungible + 1000 inflation rights);
3. **the lagging cosigner syncs up to here, then goes dark**;
4. create-utxos round 2 - now the only empty colorable outputs;
5. inflation 1: rights change lands on a round-2 output, `btc_change: None` (1000-sat UTXOs make the BTC remainder sub-dust);
6. inflation 2: spends inflation 1's rights-change UTXO;
7. the lagging cosigner catches up → replaying inflation 1 panics.

At the moment of the panic the lagging wallet's `txo` table holds the still-unspent siblings of the change tx but not the spent change target - the exact pattern we found in the live incident's wallet DB.

## Suggested direction

Mirroring the spent-assignments rescue in the `change_utxo_outpoint` arm (on a miss: `sync_wallet(FastSync, include_spent = true)`, then retry the lookup) makes this test pass end-to-end on our fork, with the rest of the multisig suite unaffected. Not included here on purpose - this looks like another instance of the "every hub operation should have a deterministic outcome, identical for all cosigners" bucket discussed in #94: here the outcome depends on the cosigner's local `txo` table state. Happy to adapt the test or the fix to whatever shape that wider rework takes.