### PR TITLE
Add RGB contract consignment import and export

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,8 @@ pub use bdk_wallet::bitcoin;
 pub use rgbstd::{
     ContractId, Txid as RgbTxid,
     containers::{
-        ConsignmentExt, Fascia, FileContent, PubWitness, Transfer as RgbTransfer, WitnessBundle,
+        ConsignmentExt, Contract as RgbContract, Fascia, FileContent, PubWitness,
+        Transfer as RgbTransfer, WitnessBundle,
     },
     persistence::UpdateRes,
     schema::SchemaId,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -719,6 +719,16 @@ pub struct RgbRuntime {
 
 impl RgbRuntime {
     #[cfg(any(feature = "electrum", feature = "esplora"))]
+    pub(crate) fn export_contract(
+        &self,
+        contract_id: ContractId,
+    ) -> Result<RgbContract, InternalError> {
+        self.stock
+            .export_contract(contract_id)
+            .map_err(InternalError::from)
+    }
+
+    #[cfg(any(feature = "electrum", feature = "esplora"))]
     pub(crate) fn accept_transfer<R: ResolveWitness>(
         &mut self,
         contract: ValidTransfer,

--- a/src/wallet/rust_only.rs
+++ b/src/wallet/rust_only.rs
@@ -24,6 +24,23 @@ pub struct ColoringInfo {
     pub nonce: Option<u64>,
 }
 
+#[cfg(any(feature = "electrum", feature = "esplora"))]
+struct ContractImportResolver;
+
+#[cfg(any(feature = "electrum", feature = "esplora"))]
+impl ResolveWitness for ContractImportResolver {
+    fn resolve_witness(&self, witness_id: RgbTxid) -> Result<WitnessStatus, WitnessResolverError> {
+        Err(WitnessResolverError::ResolverIssue(
+            Some(witness_id),
+            s!("contract consignments cannot contain witness history"),
+        ))
+    }
+
+    fn check_chain_net(&self, _: ChainNet) -> Result<(), WitnessResolverError> {
+        Ok(())
+    }
+}
+
 /// Map of contract ID and list of its beneficiaries
 pub type AssetBeneficiariesMap = BTreeMap<ContractId, Vec<BuilderSeal<GraphSeal>>>;
 
@@ -79,6 +96,208 @@ pub fn check_proxy_url(proxy_url: &str) -> Result<(), Error> {
 
 /// Rust-only APIs of the wallet.
 impl Wallet {
+    /// Export an RGB contract known to this wallet.
+    ///
+    /// The returned value is a standard RGB contract consignment. It contains the public contract
+    /// definition, not transfer history, wallet allocations or proof that this wallet owns units
+    /// of the asset.
+    ///
+    /// <div class="warning">This method is meant for special usage and is normally not needed,
+    /// use it only if you know what you're doing</div>
+    #[cfg(any(feature = "electrum", feature = "esplora"))]
+    pub fn export_asset_contract(&self, asset_id: String) -> Result<RgbContract, Error> {
+        info!(self.logger(), "Exporting asset contract '{}'...", asset_id);
+
+        let txn = self.database().begin_transaction()?;
+        txn.check_asset_exists(asset_id.clone())?;
+        txn.commit()?;
+        let contract_id = ContractId::from_str(&asset_id).expect("invalid contract ID");
+        let contract = self.rgb_runtime()?.export_contract(contract_id)?;
+
+        info!(self.logger(), "Export asset contract completed");
+        Ok(contract)
+    }
+
+    /// Validate and import an RGB contract without importing asset allocations.
+    ///
+    /// This registers the contract and its public metadata locally. It does not transfer asset
+    /// units, so a newly imported contract has a zero wallet balance. Every media file declared by
+    /// the contract and not already stored by the wallet must be supplied in `media_file_paths`.
+    ///
+    /// <div class="warning">This method is meant for special usage and is normally not needed,
+    /// use it only if you know what you're doing</div>
+    #[cfg(any(feature = "electrum", feature = "esplora"))]
+    pub fn import_asset_contract(
+        &self,
+        contract: RgbContract,
+        media_file_paths: Vec<String>,
+    ) -> Result<Metadata, Error> {
+        let contract_id = contract.contract_id();
+        let asset_id = contract_id.to_string();
+        info!(self.logger(), "Importing asset contract '{}'...", asset_id);
+
+        let asset_schema: AssetSchema = contract.schema_id().try_into()?;
+        self.check_schema_support(&asset_schema)?;
+        let validation_config = ValidationConfig {
+            chain_net: self.chain_net(),
+            trusted_typesystem: asset_schema.types(),
+            ..Default::default()
+        };
+        let resolver = ContractImportResolver;
+        let valid_contract = match contract.validate(&resolver, &validation_config) {
+            Ok(contract) => contract,
+            Err(ValidationError::InvalidConsignment(e)) => {
+                error!(self.logger(), "Contract consignment is invalid: {}", e);
+                return Err(Error::InvalidConsignment);
+            }
+            Err(ValidationError::ResolverError(e)) => {
+                warn!(self.logger(), "Contract consignment could not be resolved");
+                return Err(Error::Network {
+                    details: e.to_string(),
+                });
+            }
+        };
+
+        let txn = self.database().begin_transaction()?;
+        if txn.get_asset(asset_id.clone())?.is_some() {
+            let metadata = self.get_asset_metadata_impl(&txn, asset_id)?;
+            txn.commit()?;
+            info!(self.logger(), "Import asset contract completed");
+            return Ok(metadata);
+        }
+        let mut runtime = self.rgb_runtime()?;
+
+        let declared_attachments = self.extract_attachments(&valid_contract, asset_schema);
+        let mut expected_media = BTreeMap::new();
+        for attachment in declared_attachments {
+            let digest = hex::encode(attachment.digest);
+            if let Some(expected) = expected_media.insert(digest.clone(), attachment.clone())
+                && expected.ty != attachment.ty
+            {
+                return Err(Error::InvalidAttachments {
+                    details: format!(
+                        "contract declares multiple media types for digest '{digest}'"
+                    ),
+                });
+            }
+        }
+
+        let mut provided_media = BTreeMap::new();
+        for file_path in media_file_paths {
+            let (attachment, media) = self.file_details(&file_path)?;
+            let digest = media.digest.clone();
+            let Some(expected) = expected_media.get(&digest) else {
+                return Err(Error::InvalidAttachments {
+                    details: format!("unexpected media file with digest '{digest}'"),
+                });
+            };
+            if expected.ty != attachment.ty {
+                return Err(Error::InvalidAttachments {
+                    details: format!("media type mismatch for digest '{digest}'"),
+                });
+            }
+            if provided_media
+                .insert(digest.clone(), (file_path, media))
+                .is_some()
+            {
+                return Err(Error::InvalidAttachments {
+                    details: format!("duplicate media file with digest '{digest}'"),
+                });
+            }
+        }
+
+        let mut media_to_copy = vec![];
+        for digest in expected_media.keys() {
+            let destination = self.media_dir().join(digest);
+            if destination.exists() {
+                provided_media.remove(digest);
+                continue;
+            }
+            let Some((source, media)) = provided_media.remove(digest) else {
+                return Err(Error::InvalidAttachments {
+                    details: format!("missing media file with digest '{digest}'"),
+                });
+            };
+            media_to_copy.push((source, media, destination));
+        }
+
+        let mut saved_media_paths = vec![];
+        for (source, media, destination) in media_to_copy {
+            if let Err(e) = self.copy_media_file(source, &media) {
+                if let Err(cleanup_error) = Self::cleanup_media_files(&saved_media_paths) {
+                    warn!(
+                        self.logger(),
+                        "Failed cleaning up media after contract import error: {}", cleanup_error
+                    );
+                }
+                return Err(e);
+            }
+            saved_media_paths.push(destination);
+        }
+
+        let metadata = match self.save_imported_asset_contract(
+            txn,
+            &mut runtime,
+            contract_id,
+            asset_schema,
+            valid_contract,
+            &resolver,
+        ) {
+            Ok(metadata) => metadata,
+            Err(e) => {
+                if let Err(cleanup_error) = Self::cleanup_media_files(&saved_media_paths) {
+                    warn!(
+                        self.logger(),
+                        "Failed cleaning up media after contract import error: {}", cleanup_error
+                    );
+                }
+                return Err(e);
+            }
+        };
+        info!(self.logger(), "Import asset contract completed");
+        Ok(metadata)
+    }
+
+    #[cfg(any(feature = "electrum", feature = "esplora"))]
+    fn save_imported_asset_contract(
+        &self,
+        txn: DbTxn,
+        runtime: &mut RgbRuntime,
+        contract_id: ContractId,
+        asset_schema: AssetSchema,
+        valid_contract: ValidContract,
+        resolver: &ContractImportResolver,
+    ) -> Result<Metadata, Error> {
+        runtime.import_contract(valid_contract.clone(), resolver)?;
+        let local_asset_data = self.save_new_asset_internal(
+            &txn,
+            runtime,
+            contract_id,
+            asset_schema,
+            valid_contract,
+            None,
+        )?;
+        self.update_backup_info(&txn, false)?;
+        txn.commit()?;
+
+        let initial_supply = local_asset_data.initial_supply;
+        Ok(Metadata {
+            asset_schema: local_asset_data.asset_schema,
+            initial_supply,
+            max_supply: local_asset_data.max_supply.unwrap_or(initial_supply),
+            known_circulating_supply: local_asset_data
+                .known_circulating_supply
+                .unwrap_or(initial_supply),
+            timestamp: local_asset_data.timestamp,
+            name: local_asset_data.name,
+            precision: local_asset_data.precision,
+            ticker: local_asset_data.ticker,
+            details: local_asset_data.details,
+            token: local_asset_data.token,
+            reject_list_url: local_asset_data.reject_list_url,
+        })
+    }
+
     /// Color a PSBT.
     ///
     /// <div class="warning">This method is meant for special usage and is normally not needed, use

--- a/src/wallet/rust_only.rs
+++ b/src/wallet/rust_only.rs
@@ -24,23 +24,6 @@ pub struct ColoringInfo {
     pub nonce: Option<u64>,
 }
 
-#[cfg(any(feature = "electrum", feature = "esplora"))]
-struct ContractImportResolver;
-
-#[cfg(any(feature = "electrum", feature = "esplora"))]
-impl ResolveWitness for ContractImportResolver {
-    fn resolve_witness(&self, witness_id: RgbTxid) -> Result<WitnessStatus, WitnessResolverError> {
-        Err(WitnessResolverError::ResolverIssue(
-            Some(witness_id),
-            s!("contract consignments cannot contain witness history"),
-        ))
-    }
-
-    fn check_chain_net(&self, _: ChainNet) -> Result<(), WitnessResolverError> {
-        Ok(())
-    }
-}
-
 /// Map of contract ID and list of its beneficiaries
 pub type AssetBeneficiariesMap = BTreeMap<ContractId, Vec<BuilderSeal<GraphSeal>>>;
 
@@ -143,16 +126,18 @@ impl Wallet {
             trusted_typesystem: asset_schema.types(),
             ..Default::default()
         };
-        let resolver = ContractImportResolver;
-        let valid_contract = match contract.validate(&resolver, &validation_config) {
+        let valid_contract = match contract.validate(&DumbResolver, &validation_config) {
             Ok(contract) => contract,
             Err(ValidationError::InvalidConsignment(e)) => {
                 error!(self.logger(), "Contract consignment is invalid: {}", e);
                 return Err(Error::InvalidConsignment);
             }
             Err(ValidationError::ResolverError(e)) => {
-                warn!(self.logger(), "Contract consignment could not be resolved");
-                return Err(Error::Network {
+                warn!(
+                    self.logger(),
+                    "Unexpected resolver error while validating contract consignment: {}", e
+                );
+                return Err(Error::Internal {
                     details: e.to_string(),
                 });
             }
@@ -165,35 +150,19 @@ impl Wallet {
             info!(self.logger(), "Import asset contract completed");
             return Ok(metadata);
         }
-        let mut runtime = self.rgb_runtime()?;
-
         let declared_attachments = self.extract_attachments(&valid_contract, asset_schema);
-        let mut expected_media = BTreeMap::new();
-        for attachment in declared_attachments {
-            let digest = hex::encode(attachment.digest);
-            if let Some(expected) = expected_media.insert(digest.clone(), attachment.clone())
-                && expected.ty != attachment.ty
-            {
-                return Err(Error::InvalidAttachments {
-                    details: format!(
-                        "contract declares multiple media types for digest '{digest}'"
-                    ),
-                });
-            }
-        }
+        let expected_media = declared_attachments
+            .into_iter()
+            .map(|attachment| hex::encode(attachment.digest))
+            .collect::<BTreeSet<_>>();
 
         let mut provided_media = BTreeMap::new();
         for file_path in media_file_paths {
-            let (attachment, media) = self.file_details(&file_path)?;
+            let (_, media) = self.file_details(&file_path)?;
             let digest = media.digest.clone();
-            let Some(expected) = expected_media.get(&digest) else {
+            if !expected_media.contains(&digest) {
                 return Err(Error::InvalidAttachments {
                     details: format!("unexpected media file with digest '{digest}'"),
-                });
-            };
-            if expected.ty != attachment.ty {
-                return Err(Error::InvalidAttachments {
-                    details: format!("media type mismatch for digest '{digest}'"),
                 });
             }
             if provided_media
@@ -207,7 +176,7 @@ impl Wallet {
         }
 
         let mut media_to_copy = vec![];
-        for digest in expected_media.keys() {
+        for digest in &expected_media {
             let destination = self.media_dir().join(digest);
             if destination.exists() {
                 provided_media.remove(digest);
@@ -235,14 +204,9 @@ impl Wallet {
             saved_media_paths.push(destination);
         }
 
-        let metadata = match self.save_imported_asset_contract(
-            txn,
-            &mut runtime,
-            contract_id,
-            asset_schema,
-            valid_contract,
-            &resolver,
-        ) {
+        let import_result =
+            self.save_imported_asset_contract(txn, contract_id, asset_schema, valid_contract);
+        let metadata = match import_result {
             Ok(metadata) => metadata,
             Err(e) => {
                 if let Err(cleanup_error) = Self::cleanup_media_files(&saved_media_paths) {
@@ -262,40 +226,26 @@ impl Wallet {
     fn save_imported_asset_contract(
         &self,
         txn: DbTxn,
-        runtime: &mut RgbRuntime,
         contract_id: ContractId,
         asset_schema: AssetSchema,
         valid_contract: ValidContract,
-        resolver: &ContractImportResolver,
     ) -> Result<Metadata, Error> {
-        runtime.import_contract(valid_contract.clone(), resolver)?;
-        let local_asset_data = self.save_new_asset_internal(
+        let mut runtime = self.rgb_runtime()?;
+        runtime.import_contract(valid_contract.clone(), &DumbResolver)?;
+        self.save_new_asset_internal(
             &txn,
-            runtime,
+            &runtime,
             contract_id,
             asset_schema,
             valid_contract,
             None,
         )?;
         self.update_backup_info(&txn, false)?;
+        drop(runtime);
+        let metadata = self.get_asset_metadata_impl(&txn, contract_id.to_string())?;
         txn.commit()?;
 
-        let initial_supply = local_asset_data.initial_supply;
-        Ok(Metadata {
-            asset_schema: local_asset_data.asset_schema,
-            initial_supply,
-            max_supply: local_asset_data.max_supply.unwrap_or(initial_supply),
-            known_circulating_supply: local_asset_data
-                .known_circulating_supply
-                .unwrap_or(initial_supply),
-            timestamp: local_asset_data.timestamp,
-            name: local_asset_data.name,
-            precision: local_asset_data.precision,
-            ticker: local_asset_data.ticker,
-            details: local_asset_data.details,
-            token: local_asset_data.token,
-            reject_list_url: local_asset_data.reject_list_url,
-        })
+        Ok(metadata)
     }
 
     /// Color a PSBT.

--- a/src/wallet/test/rust_only.rs
+++ b/src/wallet/test/rust_only.rs
@@ -1,5 +1,44 @@
 use super::*;
 
+use rgbstd::{GenesisSeal, Vout};
+
+fn nia_contract(wallet: &Wallet, chain_net: ChainNet) -> RgbContract {
+    let beneficiary_txid =
+        RgbTxid::from_str("14295d5bb1a191cdb6286dc0944df938421e3dfcbf0811353ccac4100c2068c5")
+            .unwrap();
+    let beneficiary = GenesisSeal::new_random(beneficiary_txid, Vout::from_u32(1));
+    let spec = AssetSpec {
+        ticker: wallet.check_ticker(TICKER.to_string()).unwrap(),
+        name: wallet.check_name(NAME.to_string()).unwrap(),
+        details: None,
+        precision: wallet.check_precision(PRECISION).unwrap(),
+    };
+    ContractBuilder::with(
+        Identity::default(),
+        NonInflatableAsset::schema(),
+        NonInflatableAsset::types(),
+        NonInflatableAsset::scripts(),
+        chain_net,
+    )
+    .add_global_state("spec", spec)
+    .unwrap()
+    .add_global_state(
+        "terms",
+        ContractTerms {
+            text: RicardianContract::default(),
+            media: None,
+        },
+    )
+    .unwrap()
+    .add_global_state(RGB_GLOBAL_ISSUED_SUPPLY, Amount::from(AMOUNT))
+    .unwrap()
+    .add_fungible_state(RGB_STATE_ASSET_OWNER, beneficiary, AMOUNT)
+    .unwrap()
+    .issue_contract()
+    .unwrap()
+    .into_consignment()
+}
+
 #[cfg(feature = "electrum")]
 #[test]
 #[parallel]
@@ -287,6 +326,183 @@ fn save_new_asset_success() {
     assert_eq!(asset_model.precision, PRECISION);
     assert_eq!(asset_model.ticker.unwrap(), TICKER);
     assert_eq!(asset_model.schema, AssetSchema::Uda);
+}
+
+#[cfg(feature = "electrum")]
+#[test]
+#[parallel]
+fn export_asset_contract_success() {
+    initialize();
+
+    let mut issuer = get_funded_party!();
+    let asset = issuer.issue_asset_nia(None);
+    let contract = issuer
+        .wallet
+        .export_asset_contract(asset.asset_id.clone())
+        .unwrap();
+    let armored = contract.to_string();
+
+    assert!(armored.starts_with("-----BEGIN RGB CONSIGNMENT-----"));
+    assert!(armored.contains("\nId: rgb:csg:"));
+    assert!(armored.contains("\nVersion:"));
+    assert!(armored.contains("\nType: contract"));
+    assert!(armored.contains(&format!("\nContract: {}", asset.asset_id)));
+    assert!(armored.contains("\nSchema:"));
+    assert!(armored.contains("\nCheck-SHA256:"));
+    assert!(armored.ends_with("-----END RGB CONSIGNMENT-----\n"));
+    assert_eq!(RgbContract::from_str(&armored).unwrap(), contract);
+}
+
+#[cfg(feature = "electrum")]
+#[test]
+#[parallel]
+fn export_asset_contract_fail() {
+    initialize();
+
+    let mut issuer = get_funded_party!();
+    let recipient = get_empty_party!();
+    let asset = issuer.issue_asset_nia(None);
+
+    let result = recipient
+        .wallet
+        .export_asset_contract(asset.asset_id.clone());
+    assert_matches!(
+        result,
+        Err(Error::AssetNotFound { asset_id }) if asset_id == asset.asset_id
+    );
+
+    let invalid_asset_id = s!("not-an-asset-id");
+    let result = recipient
+        .wallet
+        .export_asset_contract(invalid_asset_id.clone());
+    assert_matches!(
+        result,
+        Err(Error::AssetNotFound { asset_id }) if asset_id == invalid_asset_id
+    );
+}
+
+#[cfg(feature = "electrum")]
+#[test]
+#[parallel]
+fn import_asset_contract_success() {
+    initialize();
+
+    let mut issuer = get_funded_party!();
+    let recipient = get_empty_party!();
+    let image_path = ["tests", "qrcode.png"].join(MAIN_SEPARATOR_STR);
+    let (contract_media, _) = issuer.wallet.file_details(FILE_STR).unwrap();
+
+    MOCK_CONTRACT_DATA.with_borrow_mut(|data| data.push(contract_media.clone()));
+    let nia = issuer.issue_asset_nia(None);
+    let cfa = issuer.issue_asset_cfa(None, Some(FILE_STR.to_string()));
+    MOCK_CONTRACT_DATA.with_borrow_mut(|data| data.push(contract_media.clone()));
+    let ifa = issuer.issue_asset_ifa(None, None, None);
+    MOCK_CONTRACT_DATA.with_borrow_mut(|data| data.push(contract_media));
+    let uda = issuer.issue_asset_uda(None, Some(&image_path), vec![FILE_STR]);
+
+    let imports = [
+        (nia.asset_id, AssetSchema::Nia, vec![FILE_STR.to_string()]),
+        (cfa.asset_id, AssetSchema::Cfa, vec![FILE_STR.to_string()]),
+        (ifa.asset_id, AssetSchema::Ifa, vec![FILE_STR.to_string()]),
+        (
+            uda.asset_id,
+            AssetSchema::Uda,
+            vec![FILE_STR.to_string(), image_path],
+        ),
+    ];
+
+    for (asset_id, asset_schema, media_file_paths) in imports {
+        let contract = issuer
+            .wallet
+            .export_asset_contract(asset_id.clone())
+            .unwrap();
+        let metadata = recipient
+            .wallet
+            .import_asset_contract(contract.clone(), media_file_paths.clone())
+            .unwrap();
+
+        assert_eq!(metadata.asset_schema, asset_schema);
+        assert_eq!(metadata.name, NAME);
+        assert_eq!(metadata.precision, PRECISION);
+        assert_eq!(
+            recipient
+                .wallet
+                .import_asset_contract(contract.clone(), vec![])
+                .unwrap(),
+            metadata
+        );
+        assert_eq!(
+            recipient
+                .wallet
+                .get_asset_balance(asset_id.clone())
+                .unwrap(),
+            Balance::default()
+        );
+        assert_eq!(
+            recipient
+                .wallet
+                .export_asset_contract(asset_id.clone())
+                .unwrap(),
+            contract
+        );
+        for media_file_path in media_file_paths {
+            let (_, media) = issuer.wallet.file_details(media_file_path).unwrap();
+            assert!(recipient.wallet.media_dir().join(media.digest).is_file());
+        }
+    }
+}
+
+#[cfg(feature = "electrum")]
+#[test]
+#[parallel]
+fn import_asset_contract_fail() {
+    initialize();
+
+    let mut issuer = get_funded_party!();
+    let recipient = get_empty_party!();
+    let image_path = ["tests", "qrcode.png"].join(MAIN_SEPARATOR_STR);
+    let asset = issuer.issue_asset_cfa(None, Some(FILE_STR.to_string()));
+    let contract = issuer
+        .wallet
+        .export_asset_contract(asset.asset_id.clone())
+        .unwrap();
+    let (_, expected_media) = issuer.wallet.file_details(FILE_STR).unwrap();
+    let (_, unexpected_media) = issuer.wallet.file_details(&image_path).unwrap();
+
+    let result = recipient
+        .wallet
+        .import_asset_contract(contract.clone(), vec![]);
+    let details = format!("missing media file with digest '{}'", expected_media.digest);
+    assert_matches!(result, Err(Error::InvalidAttachments { details: m }) if m == details);
+
+    let result = recipient
+        .wallet
+        .import_asset_contract(contract.clone(), vec![image_path]);
+    let details = format!(
+        "unexpected media file with digest '{}'",
+        unexpected_media.digest
+    );
+    assert_matches!(result, Err(Error::InvalidAttachments { details: m }) if m == details);
+
+    let result = recipient
+        .wallet
+        .import_asset_contract(contract, vec![FILE_STR.to_string(), FILE_STR.to_string()]);
+    let details = format!(
+        "duplicate media file with digest '{}'",
+        expected_media.digest
+    );
+    assert_matches!(result, Err(Error::InvalidAttachments { details: m }) if m == details);
+    assert_matches!(
+        recipient.wallet.get_asset_metadata(asset.asset_id.clone()),
+        Err(Error::AssetNotFound { .. })
+    );
+
+    let offline_recipient = offline_party!(get_test_wallet(true, None));
+    let wrong_network_contract = nia_contract(&offline_recipient.wallet, ChainNet::BitcoinTestnet3);
+    let result = offline_recipient
+        .wallet
+        .import_asset_contract(wrong_network_contract, vec![]);
+    assert_matches!(result, Err(Error::InvalidConsignment));
 }
 
 #[cfg(feature = "electrum")]

--- a/src/wallet/test/rust_only.rs
+++ b/src/wallet/test/rust_only.rs
@@ -1,7 +1,9 @@
 use super::*;
 
+#[cfg(feature = "electrum")]
 use rgbstd::{GenesisSeal, Vout};
 
+#[cfg(feature = "electrum")]
 fn nia_contract(wallet: &Wallet, chain_net: ChainNet) -> RgbContract {
     let beneficiary_txid =
         RgbTxid::from_str("14295d5bb1a191cdb6286dc0944df938421e3dfcbf0811353ccac4100c2068c5")

--- a/src/wallet/test/send.rs
+++ b/src/wallet/test/send.rs
@@ -168,6 +168,35 @@ fn success() {
     assert!(rcv_transfer_data.updated_at > rcv_updated_at);
     assert!(transfer_data.updated_at > updated_at);
 
+    // Contract exports never contain transfer history, and history-bearing input is rejected.
+    let exported_contract = party
+        .wallet
+        .export_asset_contract(asset.asset_id.clone())
+        .unwrap();
+    assert!(exported_contract.bundles.is_empty());
+    assert!(exported_contract.terminals.is_empty());
+    let transfer_consignment = RgbTransfer::load_file(
+        party
+            .wallet
+            .get_send_consignment_path(&asset.asset_id, &txid),
+    )
+    .unwrap();
+    assert!(!transfer_consignment.bundles.is_empty());
+    let contract_with_history = RgbContract {
+        version: transfer_consignment.version,
+        transfer: false,
+        terminals: Default::default(),
+        genesis: transfer_consignment.genesis,
+        bundles: transfer_consignment.bundles,
+        schema: transfer_consignment.schema,
+        types: transfer_consignment.types,
+        scripts: transfer_consignment.scripts,
+    };
+    let result = rcv_party
+        .wallet
+        .import_asset_contract(contract_with_history, vec![]);
+    assert_matches!(result, Err(Error::InvalidConsignment));
+
     // change is unspent once transfer is Settled
     let unspents = party.list_unspents(true);
     let change_unspent = unspents


### PR DESCRIPTION
Closes #56

## Problem

Asset registries need a standard RGB contract consignment that can be verified and imported independently of an asset transfer. An asset ID alone cannot reconstruct or validate the contract, while a transfer consignment carries ownership history that is not appropriate for contract preload.

## Changes

- re-export `RgbContract` and add `Wallet::export_asset_contract`
- add one `Wallet::import_asset_contract(contract, media_file_paths)` API returning the imported asset `Metadata`
- validate the contract schema, wallet network, and contract consignment before mutation
- support NIA, CFA, IFA, and UDA contract metadata and declared media
- make repeated imports idempotent when the asset already exists in the wallet database
- verify that exported contracts contain no transfer bundles or terminals

Both APIs follow the existing rust-only feature model and are available with the `electrum` or `esplora` feature. The exported value uses rgb-ops' standard ASCII-armored `RGB CONSIGNMENT` `Display`/`FromStr` representation.

## Implementation notes

- contract-only import registers public contract identity and metadata; it creates no allocation, transfer, or wallet ownership, so the imported balance is zero
- rgb-ops rejects bundles and terminals in a contract consignment before witness resolution; the import uses the existing `DumbResolver` required by the validation API
- RGB Stock remains the persistence authority: `Stock::import_contract` uses its existing autosave transaction behavior
- media ingestion reuses the existing `file_details`, `copy_media_file`, and `cleanup_media_files` helpers; supplied files are matched to contract attachments by committed digest, while declared media metadata remains authoritative
- database metadata and backup state use the existing `save_new_asset_internal`, `get_asset_metadata_impl`, and `update_backup_info` paths in one database transaction
- the RGB runtime is released before metadata is read so UDA metadata can reopen the persisted runtime without contending on the wallet lock
- the existing `save_new_asset` transfer-consignment API and behavior are unchanged

## Review scope correction

The review-requested scope reduction is complete. The patch was rebuilt on current `master` and reduced from 7 files / 1,033 additions to 5 files / 428 additions. It removes:

- custom `RgbRuntime` persistence flags and drop behavior
- unrelated read-path and offline-build changes
- `ImportAssetContractResult` and the media wrapper type
- the repair/state-detection protocol
- duplicated media persistence and fsync code
- standalone repair, lock-contention, and duplicated transfer-cycle tests

## Validation

Local validation on the current head (`2741520`) is green:

- formatting, including formatted doc comments
- strict Clippy with all features/all targets, no default features/all targets, Electrum-only/all targets, and Esplora-only/all targets
- no-default-feature suite: 49 passed
- documentation tests: 2 passed
- contract-focused Docker tests: 4 passed
- modified end-to-end `send::success`: passed

The full GitHub Actions matrix was green on the preceding head (`210a15f`). Fresh workflow runs were created for `2741520`, but GitHub currently marks them `action_required`; a maintainer must approve the fork workflows before the authoritative Linux matrix can run.

The local Docker harness's full-service startup is not portable to this Apple Silicon host because its optional Esplora fixture is amd64-only. The focused integration tests were therefore run against the repository's isolated bitcoind, primary Electrum, RGB proxy, and modified-proxy fixtures. No test-harness changes are part of this PR.

## Coverage

Tests cover canonical armor round-trip, all four supported schemas, declared media, missing/unexpected/duplicate media, wrong-network rejection, malformed and unknown asset IDs, zero-balance semantics, idempotent re-import, export after a settled transfer, and rejection of history-bearing contract input.
