### PR TITLE
Failing test: receiver ignores a pre-existing proxy NACK and gets stuck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,35 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test_and_coverage:
-    timeout-minutes: 45
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: llvm-tools-preview
-          toolchain: stable
-      - name: Install llvm-cov
-        env:
-          LLVM_COV_RELEASES: https://github.com/taiki-e/cargo-llvm-cov/releases
-        run: |
-          host=$(rustc -Vv | grep host | sed 's/host: //')
-          curl -fsSL $LLVM_COV_RELEASES/latest/download/cargo-llvm-cov-$host.tar.gz | tar xzf - -C "$HOME/.cargo/bin"
-      - name: Test with all features and generate coverage report
-        run: ./tests/coverage.sh --ci
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v6
-        with:
-          fail_ci_if_error: true
-          file: coverage.lcov
-          flags: rust
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  test_features:
+  repro_test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
 
@@ -47,31 +19,5 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: ""
-      - name: Test with electrum feature
-        run: |
-          cargo test --profile reldebug --no-default-features --features electrum get_fee_estimation::success_electrum -- --ignored
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features electrum go_online::fail
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features electrum send::min_confirmations_electrum
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features electrum send::min_relay_fee_electrum
-      - name: Test with esplora feature
-        run: |
-          cargo test --profile reldebug --no-default-features --features esplora get_fee_estimation::success_esplora -- --ignored
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features esplora go_online::fail
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features esplora send::min_confirmations_esplora
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features esplora send::min_relay_fee_esplora
-      - name: Test with no default features
-        run: |
-          cargo test --profile reldebug --no-default-features
-
-  test_doc:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          rustflags: ""
-      - name: Test documentation
-        run: |
-          cargo test --doc
+      - name: Run the repro test (starts the regtest services, then runs only this test)
+        run: cargo test --profile reldebug --no-default-features --features electrum send::nack_pre_existing_receiver_fails

--- a/src/wallet/test/send.rs
+++ b/src/wallet/test/send.rs
@@ -2492,6 +2492,61 @@ fn nack() {
 #[cfg(feature = "electrum")]
 #[test]
 #[parallel]
+fn nack_pre_existing_receiver_fails() {
+    initialize();
+
+    let amount: u64 = 66;
+
+    // wallets
+    let mut party = get_funded_party!();
+    let mut rcv_party = get_funded_party!();
+
+    // issue
+    let asset = party.issue_asset_nia(None);
+
+    // send with donation set to false
+    let receive_data = rcv_party.blind_receive();
+    let recipient_map = HashMap::from([(
+        asset.asset_id.clone(),
+        vec![Recipient {
+            assignment: Assignment::Fungible(amount),
+            recipient_id: receive_data.recipient_id.clone(),
+            witness_data: None,
+            transport_endpoints: TRANSPORT_ENDPOINTS.clone(),
+        }],
+    )]);
+    let txid = party.send_retry(&recipient_map);
+    assert!(!txid.is_empty());
+    assert!(rcv_party.check_test_transfer_status_recipient(
+        &receive_data.recipient_id,
+        TransferStatus::WaitingCounterparty
+    ));
+
+    // a NACK is recorded on the proxy before the receiver processes the consignment
+    let proxy_client = get_proxy_client(None);
+    proxy_client
+        .post_ack(&receive_data.recipient_id, false)
+        .unwrap();
+
+    // the receiver validates the consignment but its ACK is refused by the proxy ("Cannot change
+    // ACK"): the sender will never see an ACK and never broadcast, so the receive transfer must
+    // be failed rather than left waiting for confirmations of a TX that will never appear
+    rcv_party.wait_for_refresh(None);
+    assert!(
+        rcv_party.check_test_transfer_status_recipient(
+            &receive_data.recipient_id,
+            TransferStatus::Failed
+        )
+    );
+
+    // the sender fails as usual
+    party.wait_for_refresh(Some(&asset.asset_id));
+    assert!(party.check_test_transfer_status_sender(&txid, TransferStatus::Failed));
+}
+
+#[cfg(feature = "electrum")]
+#[test]
+#[parallel]
 fn no_change_on_pending_send() {
     initialize();
 


### PR DESCRIPTION
When a receiver tries to ACK a consignment but the proxy already has a NACK on that recipient, the proxy returns a "Cannot change ACK" error. That error is dropped, so the receiver acts as if the ACK went through and moves the transfer to WaitingBroadcast. The sender never broadcasts, so the transfer just sits there with a balance that will never arrive, until it expires.

The existing `nack` test only checks the sender side. This test adds the receiver side: with a NACK already on the proxy, the receive should end up Failed, but on master it ends up in WaitingBroadcast.

I trimmed the test workflow in this PR to run only this one test, so the failure is easy to see.