### PR TITLE
Failing tests: save_new_asset panics on a bad consignment and is not idempotent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,35 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test_and_coverage:
-    timeout-minutes: 45
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: llvm-tools-preview
-          toolchain: stable
-      - name: Install llvm-cov
-        env:
-          LLVM_COV_RELEASES: https://github.com/taiki-e/cargo-llvm-cov/releases
-        run: |
-          host=$(rustc -Vv | grep host | sed 's/host: //')
-          curl -fsSL $LLVM_COV_RELEASES/latest/download/cargo-llvm-cov-$host.tar.gz | tar xzf - -C "$HOME/.cargo/bin"
-      - name: Test with all features and generate coverage report
-        run: ./tests/coverage.sh --ci
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v6
-        with:
-          fail_ci_if_error: true
-          file: coverage.lcov
-          flags: rust
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  test_features:
+  repro_test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
 
@@ -47,31 +19,5 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: ""
-      - name: Test with electrum feature
-        run: |
-          cargo test --profile reldebug --no-default-features --features electrum get_fee_estimation::success_electrum -- --ignored
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features electrum go_online::fail
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features electrum send::min_confirmations_electrum
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features electrum send::min_relay_fee_electrum
-      - name: Test with esplora feature
-        run: |
-          cargo test --profile reldebug --no-default-features --features esplora get_fee_estimation::success_esplora -- --ignored
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features esplora go_online::fail
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features esplora send::min_confirmations_esplora
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features esplora send::min_relay_fee_esplora
-      - name: Test with no default features
-        run: |
-          cargo test --profile reldebug --no-default-features
-
-  test_doc:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          rustflags: ""
-      - name: Test documentation
-        run: |
-          cargo test --doc
+      - name: Run the repro tests (starts the regtest services, then runs only these tests)
+        run: cargo test --profile reldebug --no-default-features --features electrum -- save_new_asset_invalid_consignment_fail save_new_asset_twice_success

--- a/src/wallet/test/rust_only.rs
+++ b/src/wallet/test/rust_only.rs
@@ -818,6 +818,110 @@ fn save_new_asset_fail() {
 #[cfg(feature = "electrum")]
 #[test]
 #[parallel]
+fn save_new_asset_invalid_consignment_fail() {
+    initialize();
+
+    let mut party = get_funded_party!();
+    let mut rcv_party = get_empty_party!();
+    let asset = party.issue_asset_nia(None);
+    let receive_data = rcv_party.witness_receive();
+    let recipient_map = HashMap::from([(
+        asset.asset_id.clone(),
+        vec![Recipient {
+            assignment: Assignment::Fungible(10),
+            recipient_id: receive_data.recipient_id.clone(),
+            witness_data: Some(WitnessData {
+                amount_sat: 1000,
+                blinding: None,
+            }),
+            transport_endpoints: TRANSPORT_ENDPOINTS.clone(),
+        }],
+    )]);
+    let txid = party.send_retry(&recipient_map);
+    let consignment_path = party
+        .wallet
+        .get_send_consignment_path(&asset.asset_id, &txid);
+    let consignment = RgbTransfer::load_file(consignment_path).unwrap();
+
+    // a wrong witness TXID: the consignment's witness cannot be resolved off-chain and the real TX
+    // is not on chain (donation is false, the sender has not broadcast), so validation fails. A
+    // caller-supplied consignment that fails validation must be reported as an error, not panic
+    let result =
+        rcv_party
+            .wallet
+            .save_new_asset(rcv_party.online, consignment, FAKE_TXID.to_string());
+    assert!(
+        matches!(
+            result,
+            Err(Error::InvalidConsignment) | Err(Error::Network { .. })
+        ),
+        "unexpected result: {result:?}"
+    );
+}
+
+#[cfg(feature = "electrum")]
+#[test]
+#[parallel]
+fn save_new_asset_twice_success() {
+    initialize();
+
+    let mut party = get_funded_party!();
+    let mut rcv_party = get_empty_party!();
+    let asset = party.issue_asset_nia(None);
+    let receive_data = rcv_party.witness_receive();
+    let recipient_map = HashMap::from([(
+        asset.asset_id.clone(),
+        vec![Recipient {
+            assignment: Assignment::Fungible(10),
+            recipient_id: receive_data.recipient_id.clone(),
+            witness_data: Some(WitnessData {
+                amount_sat: 1000,
+                blinding: None,
+            }),
+            transport_endpoints: TRANSPORT_ENDPOINTS.clone(),
+        }],
+    )]);
+    let txid = party.send_retry(&recipient_map);
+    let consignment_path = party
+        .wallet
+        .get_send_consignment_path(&asset.asset_id, &txid);
+    let consignment = RgbTransfer::load_file(consignment_path).unwrap();
+
+    // the contract is expected to already be in the stock (as after accept_transfer_consignment)
+    let contract = consignment.clone().into_contract();
+    let asset_schema: AssetSchema = consignment.schema_id().try_into().unwrap();
+    let validation_config = ValidationConfig {
+        chain_net: rcv_party.wallet.chain_net(),
+        trusted_typesystem: asset_schema.types(),
+        ..Default::default()
+    };
+    let mut runtime = rcv_party.wallet.rgb_runtime().unwrap();
+    let valid_contract = contract
+        .validate(&DumbResolver, &validation_config)
+        .unwrap();
+    runtime
+        .import_contract(valid_contract, rcv_party.wallet.blockchain_resolver())
+        .unwrap();
+    drop(runtime);
+
+    rcv_party
+        .wallet
+        .save_new_asset(rcv_party.online, consignment.clone(), txid.clone())
+        .unwrap();
+    assert!(rcv_party.db_check_asset_exists(&asset.asset_id).is_ok());
+
+    // a caller retrying (e.g. after a crash between saving and its own bookkeeping) must not get
+    // an opaque DB constraint error for an asset that is already saved
+    rcv_party
+        .wallet
+        .save_new_asset(rcv_party.online, consignment, txid)
+        .unwrap();
+    assert!(rcv_party.db_check_asset_exists(&asset.asset_id).is_ok());
+}
+
+#[cfg(feature = "electrum")]
+#[test]
+#[parallel]
 fn send_end_db_update_only_fail() {
     initialize();
 


### PR DESCRIPTION
`save_new_asset` is a public API. It validates the caller's consignment with `.expect(...)`, so a bad consignment, or a temporary indexer error during validation, panics and takes down the whole process instead of returning an error. The receive path already handles these same cases by returning an error.

- `save_new_asset_invalid_consignment_fail`: passes a consignment whose witness can't be resolved. Expected: an error. On master: it panics.
- `save_new_asset_twice_success`: calls `save_new_asset` twice for the same contract (e.g. a caller retrying after a crash). Expected: the second call is a no-op. On master: it fails with a raw DB unique-constraint error.