### PR TITLE
Failing tests: check_proxy discards the underlying transport error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,35 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test_and_coverage:
-    timeout-minutes: 45
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-      - name: Setup rust toolchain
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          components: llvm-tools-preview
-          toolchain: stable
-      - name: Install llvm-cov
-        env:
-          LLVM_COV_RELEASES: https://github.com/taiki-e/cargo-llvm-cov/releases
-        run: |
-          host=$(rustc -Vv | grep host | sed 's/host: //')
-          curl -fsSL $LLVM_COV_RELEASES/latest/download/cargo-llvm-cov-$host.tar.gz | tar xzf - -C "$HOME/.cargo/bin"
-      - name: Test with all features and generate coverage report
-        run: ./tests/coverage.sh --ci
-      - name: Upload coverage report
-        uses: codecov/codecov-action@v6
-        with:
-          fail_ci_if_error: true
-          file: coverage.lcov
-          flags: rust
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  test_features:
+  repro_test:
     timeout-minutes: 30
     runs-on: ubuntu-latest
 
@@ -47,31 +19,5 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: ""
-      - name: Test with electrum feature
-        run: |
-          cargo test --profile reldebug --no-default-features --features electrum get_fee_estimation::success_electrum -- --ignored
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features electrum go_online::fail
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features electrum send::min_confirmations_electrum
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features electrum send::min_relay_fee_electrum
-      - name: Test with esplora feature
-        run: |
-          cargo test --profile reldebug --no-default-features --features esplora get_fee_estimation::success_esplora -- --ignored
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features esplora go_online::fail
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features esplora send::min_confirmations_esplora
-          SKIP_INIT=1 cargo test --profile reldebug --no-default-features --features esplora send::min_relay_fee_esplora
-      - name: Test with no default features
-        run: |
-          cargo test --profile reldebug --no-default-features
-
-  test_doc:
-    timeout-minutes: 30
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          rustflags: ""
-      - name: Test documentation
-        run: |
-          cargo test --doc
+      - name: Run the repro tests (offline unit tests, no services needed)
+        run: cargo test --profile reldebug --no-default-features --features electrum -- test_check_proxy_invalid_body_error_details test_check_proxy_connection_error_details

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1144,6 +1144,42 @@ mod tests {
         mock.assert();
     }
 
+    #[cfg(any(feature = "electrum", feature = "esplora"))]
+    #[test]
+    fn test_check_proxy_invalid_body_error_details() {
+        // server returns HTTP 200 with a body that is not a JSON-RPC response: the transport
+        // error (body decoding) must be reported, not the generic connection message
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("not json")
+            .create();
+        let result = check_proxy(&server.url());
+        assert_matches!(
+            result,
+            Err(Error::Proxy { details }) if details != "unable to connect to proxy"
+        );
+        mock.assert();
+    }
+
+    #[cfg(any(feature = "electrum", feature = "esplora"))]
+    #[test]
+    fn test_check_proxy_connection_error_details() {
+        // bind then drop a listener to get a port that refuses connections: the transport error
+        // (connection refused) must be reported, not the generic connection message
+        let port = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let result = check_proxy(&format!("http://127.0.0.1:{port}"));
+        assert_matches!(
+            result,
+            Err(Error::Proxy { details }) if details != "unable to connect to proxy"
+        );
+    }
+
     #[test]
     fn test_load_rgb_runtime_corrupt_stock() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
check_proxy reports every transport failure as "unable to connect to proxy", no matter the cause. Connection refused, a bad response body, TLS, they all come back the same. It already forwards JSON-RPC error messages from the proxy, so dropping the transport error is just an oversight, and it makes a misconfigured proxy annoying to debug.

- `test_check_proxy_invalid_body_error_details`: proxy answers with a body that isn't a valid response. Expected: an error that reflects that. On master: "unable to connect to proxy".
- `test_check_proxy_connection_error_details`: nothing is listening on the port. Expected: the connection error. On master: "unable to connect to proxy".